### PR TITLE
Static batched decode (LLaMA + Qwen3): B independent sequences per step, up to 41x aggregate throughput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ logs/target/
 .project
 .classpath
 .vscode/
+external/

--- a/BATCHED_DECODE.md
+++ b/BATCHED_DECODE.md
@@ -266,6 +266,25 @@ shared prompt:
 
 +104% throughput and prefix sharing also halves peak KV blocks (296→151), all bit-exact.
 
+## On-device sampling (`-Dbatch.decode.deviceSample=true`, default for greedy)
+
+Profiling (nsys) showed the engine was **host-bound**: each step copied the full
+`paddedB×vocab` logits tensor D2H (~65 MB on Llama, ~78 MB on Qwen) and ran a CPU argmax over
+it, stalling the GPU between steps. `batchedArgmaxLogits` (one workgroup per row) does the
+greedy argmax **on the GPU**; the logits stay device-side and only **B token ids** cross to the
+host.
+
+Llama-1B, B=128, 512-request continuous+paged+prefix, identical greedy output:
+
+| sampling | D2H/step | wall | gen tok/s |
+|----------|---------:|-----:|----------:|
+| host | ~65 MB | 7.66 s | 2344 |
+| **on-device** | ~0.5 KB | 5.88 s | **3057** |
+
+**+30% throughput** — the D2H copy collapses (115 ms → 0.03 ms in the trace) and the CPU scan
+is gone; GPU kernel work per step is unchanged, so the gain is pure host-stall removal. Auto-off
+for temperature sampling (which still needs logits on the host).
+
 ## Reproduce
 
 ### 1. TornadoVM (CUDA backend + tensor-core MMA)

--- a/BATCHED_DECODE.md
+++ b/BATCHED_DECODE.md
@@ -1,13 +1,15 @@
-# Static batched decode (LLaMA FP16)
+# Static batched decode (LLaMA / Qwen3 FP16)
 
 Decode **B independent sequences at once**, one token per step, each attending its
 **own** KV cache. Turns the bandwidth-bound single-token matvecs of decode into
 compute-bound tensor-core GEMMs (one weight read amortized across B tokens), so
 aggregate throughput scales ~linearly with B until the 128-row MMA tile fills.
 
-Measured **41× aggregate throughput** vs single-stream decode on an RTX 4090
+Measured up to **41× aggregate throughput** vs single-stream decode on an RTX 4090
 (Llama-3.2-1B FP16), output verified coherent + bit-exact against the single-stream
-greedy reference.
+greedy reference. Runs on the TornadoVM **CUDA backend** (tensor-core MMA).
+Both **LLaMA** and **Qwen3** are supported (Qwen3 adds per-head Q/K RMS norm + split-
+half RoPE).
 
 ---
 
@@ -90,6 +92,13 @@ addressing:
 The math (RoPE rotation, online-softmax flash attention, register-partitioned P·V)
 is untouched; both forks only change the index into the KV cache.
 
+**Qwen3** reuses the same pattern: `Qwen3FP16LayersBatchDecodeMMA` keeps the per-head
+Q/K RMS-norm task (`batchedFusedQKRmsNormPacked`, per-token — reused as-is) and swaps in
+`batchedDecodeRopeWithKVCacheQwen3Packed` (split-half RoPE, per-slot) +
+`batchedDecodeAttentionFP16Out` (the same per-slot flash kernel, parameterized by
+`qDim`/`nEmbdHead`/`gqa`). The engine dispatches on model type; embeddings and the
+batched-logits GEMM are model-agnostic.
+
 ### KV cache layout (B-sized)
 
 Each slot owns a contiguous region; `batchIdx` stride = `numLayers·ctx·kvDim`.
@@ -139,8 +148,10 @@ requests, not replication):
 
 ## Performance
 
-RTX 4090, Llama-3.2-1B FP16, `ctx=512`, 64 decode steps, CUDA graphs on,
-steady-state (capture steps excluded).
+RTX 4090, TornadoVM **CUDA backend**, FP16, `ctx=512`, CUDA graphs on, steady-state
+(capture steps excluded).
+
+**Llama-3.2-1B** (16 layers, vocab 128256):
 
 | config | aggregate tok/s | vs single-stream | per-step latency |
 |-------:|----------------:|-----------------:|-----------------:|
@@ -151,6 +162,18 @@ steady-state (capture steps excluded).
 
 CUDA graphs (`-Dbatch.decode.cudaGraphs`, default on) cut a uniform ~6% off per-step
 (dispatch overhead across the 2+N graphs).
+
+**Across models** (largest B that fits 24 GB; deeper/wider → higher per-step, so B is
+capped lower):
+
+| model | layers · dim · vocab | single-stream | batched (B) | aggregate | speedup |
+|-------|----------------------|--------------:|:-----------:|----------:|--------:|
+| Llama-3.2-1B | 16 · 2048 · 128256 | 101 tok/s | 128 | 4175 tok/s | 41× |
+| Qwen3-1.7B   | 28 · 2048 · 151936 |  48 tok/s |  64 | 1433 tok/s | 30× |
+| Qwen3-4B     | 36 · 2560 · 151936 |  39 tok/s |  32 |  405 tok/s | 10× |
+
+All bit-exact vs the single-stream greedy reference (`all B streams identical: true`)
+and coherent.
 
 **Operating point.** Per-step latency is ~flat (29–31 ms) from B=8 to B=128: every
 step runs at `paddedBatch = 128` (the MMA tile is 128 rows) and the logits GEMM spans
@@ -166,16 +189,17 @@ launch overhead, which is why CUDA graphs help only marginally.
 
 ### 1. TornadoVM (CUDA backend + tensor-core MMA)
 
-Requires a TornadoVM with the **CUDA/PTX backend** and the **MMA `KernelContext`**
-API (`mmaFragment` / `mmaLoadA` / `mmaMultiply`, `HalfFloatArray`) — the same
-TornadoVM the `feat/mma_cuda` GPULlama3 branch already needs. Tested against
-**TornadoVM 5.0.1-jdk21-dev** built with the PTX backend on **JDK 21**.
+Requires a TornadoVM with the **CUDA backend** and the **MMA `KernelContext`** API
+(`mmaFragment` / `mmaLoadA` / `mmaMultiply`, `HalfFloatArray`) — the same TornadoVM the
+`feat/mma_cuda` GPULlama3 branch already needs. Tested against **TornadoVM
+5.0.1-jdk21-dev**, CUDA backend, **JDK 21**. (All numbers here are from the CUDA
+backend.)
 
 ```bash
 git clone https://github.com/beehive-lab/TornadoVM
 cd TornadoVM
-# JDK 21; build the CUDA/PTX backend (installs artifacts into ~/.m2)
-make BACKEND=ptx
+# JDK 21; build the CUDA backend (installs artifacts into ~/.m2)
+make BACKEND=cuda
 export TORNADOVM_HOME=$PWD/dist/tornadovm-*-cuda
 ```
 
@@ -213,9 +237,10 @@ bit-exact vs a CPU reference).
 
 ## Limitations / next
 
-- **FP16 LLaMA only.** Q8_0 and other architectures reuse the same pattern but need
-  their own decode layer graph. Qwen3 is blocked upstream (empty output on this
-  TornadoVM build) independent of this work.
+- **FP16 LLaMA + Qwen3.** Q8_0 and other architectures reuse the same pattern but need
+  their own decode layer graph. Qwen3-8B produces garbage in the **stock** decode path
+  on this build (independent of batched decode — the engine faithfully reproduces the
+  stock output); Qwen3-1.7B/4B are fine.
 - **Same prompt length across slots** (static batching). Ragged prompts / iteration-
   level (continuous) batching are the follow-up — the per-slot `seqPositions` +
   per-slot KV base already support per-slot positions.

--- a/BATCHED_DECODE.md
+++ b/BATCHED_DECODE.md
@@ -207,6 +207,31 @@ so identical token counts and all outputs mutually prefix-consistent):
 draining each wave to its longest request. The gap widens with more length variance.
 Correctness under scheduling = all completed outputs are mutually prefix-consistent.
 
+## PagedAttention (`-Dbatch.decode.paged=true`, LLaMA)
+
+The contiguous KV cache reserves the full `ctx` per slot — `B·ctx` token-slots even
+when most sequences are short. Paging stores KV in a **shared pool of fixed-size blocks**
+(`blockSize` positions each) addressed through a per-slot **block table**; the two decode
+KV kernels index `blockTable[b][pos/blockSize]` instead of `pos·kvDim`. Blocks are
+allocated on demand as a sequence grows and returned to the pool on eviction, so the pool
+is sized to **actual concurrent demand**, not the worst case.
+
+Same 512-request continuous workload (Llama-1B, B=128, ctx=512, blockSize=16):
+
+| KV cache | pool | peak used | throughput | correct |
+|----------|-----:|----------:|-----------:|:-------:|
+| contiguous | 4096 MB (=B·ctx reservation) | — | 1972 tok/s | ✓ |
+| paged, 768-block pool | 768 MB | 372 blk (48%) | 1971 tok/s | ✓ |
+| paged, 384-block pool | 384 MB | 372 blk (97%) | 1939 tok/s | ✓ |
+
+**~10.7× less KV memory** (384 MB vs 4096 MB) at ~1% throughput overhead, output still
+bit-exact. The pool floor is the peak concurrent block demand (~372 here); undersizing it
+throws a clear `KV block pool exhausted` (the point where admission control / backpressure
+takes over — the vLLM behavior). One reserved *scratch* block absorbs the KV writes of
+inactive slots (they still execute the kernels each step) so they never corrupt a live
+block. Paging is the prerequisite for prefix caching (share a prompt's blocks across
+requests via the block table + refcounting).
+
 ## Reproduce
 
 ### 1. TornadoVM (CUDA backend + tensor-core MMA)

--- a/BATCHED_DECODE.md
+++ b/BATCHED_DECODE.md
@@ -207,7 +207,7 @@ so identical token counts and all outputs mutually prefix-consistent):
 draining each wave to its longest request. The gap widens with more length variance.
 Correctness under scheduling = all completed outputs are mutually prefix-consistent.
 
-## PagedAttention (`-Dbatch.decode.paged=true`, LLaMA)
+## PagedAttention (`-Dbatch.decode.paged=true`, LLaMA + Qwen3)
 
 The contiguous KV cache reserves the full `ctx` per slot — `B·ctx` token-slots even
 when most sequences are short. Paging stores KV in a **shared pool of fixed-size blocks**
@@ -253,6 +253,18 @@ blocks) instead of 512×, and its KV blocks are shared. Output still bit-exact (
 requests mutually prefix-consistent). The win scales with prefix length / request count. The
 prefix is block-aligned down (`sharedPrefixLen = ⌊(promptLen-1)/blockSize⌋·blockSize`) so a
 request only ever writes into its own private blocks; shared blocks stay read-only.
+
+The full stack (batched decode → continuous → paging → prefix caching) runs on **Qwen3**
+as well (Qwen3 adds a split-half paged RoPE kernel; the paged flash kernel is shared since
+`qDim == nHeads·nEmbdHead`). Qwen3-1.7B, 256-request continuous+paged workload, 48-tok
+shared prompt:
+
+| Qwen3-1.7B | steps | gen tok/s | requests/s | peak KV blocks |
+|--|------:|----------:|-----------:|---------------:|
+| paged, no prefix cache | 405 | 465 | 13.6 | 296 |
+| **paged + prefix cache** | **193** | **949** | **27.7** | **151** |
+
++104% throughput and prefix sharing also halves peak KV blocks (296→151), all bit-exact.
 
 ## Reproduce
 

--- a/BATCHED_DECODE.md
+++ b/BATCHED_DECODE.md
@@ -1,0 +1,223 @@
+# Static batched decode (LLaMA FP16)
+
+Decode **B independent sequences at once**, one token per step, each attending its
+**own** KV cache. Turns the bandwidth-bound single-token matvecs of decode into
+compute-bound tensor-core GEMMs (one weight read amortized across B tokens), so
+aggregate throughput scales ~linearly with B until the 128-row MMA tile fills.
+
+Measured **41× aggregate throughput** vs single-stream decode on an RTX 4090
+(Llama-3.2-1B FP16), output verified coherent + bit-exact against the single-stream
+greedy reference.
+
+---
+
+## Why batching wins decode
+
+Single-token decode is **memory-bound**: every projection reads the full weight
+matrix to produce one output vector (arithmetic intensity ~1). The GPU stalls on
+HBM bandwidth; tensor cores sit idle.
+
+Batch B tokens that share the same weights and each weight row is read **once** and
+applied to **all B** tokens — arithmetic intensity ~B, i.e. a GEMM. Past B≈16 the
+projections become compute-bound and the tensor cores engage. Attention does *not*
+batch this way (each sequence has its own KV), but it is a small fraction of the
+decode FLOPs, so the projection win dominates.
+
+```
+             single-token decode              static batched decode (B)
+             ────────────────────             ─────────────────────────
+  weight W    read once  ─┐                     read once ─┐
+  token x0    ───────────┼─> y0                 ──────────┼─> y0
+  token x1    (next step: read W again)         ──────────┼─> y1     one GEMM,
+  token x2    (read W again) ...                ──────────┼─> y2     W read once
+   ...                                          ──────────┘  ...
+  intensity ~1  (HBM-bound)                     intensity ~B (compute-bound)
+```
+
+---
+
+## Design
+
+### Engine loop (`bench/BatchedDecodeEngine.java`)
+
+One step routine serves **both** phases. Prompt tokens are fed with logits
+discarded — this fills every slot's KV region with the *same* RoPE the decode step
+uses, so there is no prefill/decode cache mismatch. Then generated tokens feed back.
+
+```
+  prompt "…paint."   ┌──────────────────────────────────────────────┐
+        │            │  for each step:                              │
+        ▼            │    host: write B token embeddings → embXBatch │
+  ┌───────────┐      │          write positions → seqPositions[B]    │
+  │  PREFILL  │      │    GPU:  activation → L0 → L1 → … → L15 → logit│
+  │ P tokens  │──────│    host: sample B rows of logitsBatch         │
+  │(no logits)│      └──────────────────────────────────────────────┘
+  └───────────┘                        │
+        │                              ▼
+        ▼                      ┌────────────────┐
+  ┌───────────┐   per step     │  B next tokens │  greedy → all B identical
+  │  DECODE   │───────────────>│  (one / slot)  │  temp>0 → B divergent streams
+  │ N steps   │                └────────────────┘
+  └───────────┘
+```
+
+### Per-step task-graph pipeline (2 + N graphs)
+
+```
+ embXBatch(FP16 B×dim)
+      │  [0] prefillActivation      FP16 → FP32  wrapXBatch
+      ▼
+ ┌─────────────────  [1..N] batchDecodeLayer_i  (12 tasks, all GEMMs on MMA) ─────────────────┐
+ │  batch_attn_rms → batch_attn_rms_apply → qkvProj(MMA) → batch_rope_kv* → batch_attention*  │
+ │  → woProj(MMA) → batch_ffn_rms → batch_ffn_rms_apply → gateUpProj(MMA) → swiglu            │
+ │  → w2Proj(MMA) → w2Resid                                                                    │
+ │      (*) the only decode-specific kernels: per-slot position + per-slot KV base            │
+ └─────────────────────────────────────────────────────────────────────────────────────────┘
+      │  wrapXBatch (B×dim, persists to next layer)
+      ▼
+ [N+1] batchLogits    final RMS → gemmMMA over vocab(128256) → logitsBatch (B×vocab, FP32)
+```
+
+The 12-task layer pipeline is **identical** to the existing batched-prefill MMA
+layer (`LlamaFP16LayersBatchPrefillMMA`). Only two kernels change, and only in KV
+addressing:
+
+| kernel | prefill (one sequence) | decode (B sequences) |
+|--------|------------------------|----------------------|
+| RoPE + KV write | `batchedRopeWithKVCachePacked` — `pos = start + b`, one shared cache | `batchedDecodeRopeWithKVCachePacked` — `pos = seqPositions[b]`, per-slot base |
+| flash attention | `batchedFlashAttentionFP16Out` — shared causal KV | `batchedDecodeAttentionFP16Out` — own KV region per slot |
+
+The math (RoPE rotation, online-softmax flash attention, register-partitioned P·V)
+is untouched; both forks only change the index into the KV cache.
+
+### KV cache layout (B-sized)
+
+Each slot owns a contiguous region; `batchIdx` stride = `numLayers·ctx·kvDim`.
+
+```
+ keyCacheBatch  [ slot0 | slot1 | … | slot B-1 ]      size = B · numLayers · ctx · kvDim
+                    │
+                    └─ [ layer0 | layer1 | … ]         stride numLayers·ctx·kvDim
+                          │
+                          └─ [ pos0 | pos1 | … ]       row = pos·kvDim, written at seqPositions[slot]
+```
+
+Because the engine (not `State`) owns this buffer, `ctx` is capped independently
+(default 512) to keep `B·L·ctx·kvDim` in VRAM.
+
+### Static batching
+
+All slots advance one position per step, so `seqPositions` is the same scalar for
+every slot at every step. The load-bearing part is the per-slot KV **base** address,
+not the position — the `IntArray seqPositions` keeps the door open for ragged /
+continuous batching later.
+
+---
+
+## Correctness
+
+Greedy sampling with B copies of the same prompt → **all B streams are bit-exact
+identical AND equal to the single-stream greedy reference**. Each slot independently
+reproduces the reference, so the per-slot forward (including per-slot KV) is correct.
+
+```
+[verify] mode=greedy: all 128 streams identical (== single-stream greedy ref): true
+```
+
+Temperature sampling with a per-slot RNG → **B distinct, individually coherent**
+continuations, proving the KV regions are genuinely independent (real concurrent
+requests, not replication):
+
+```
+[verify] mode=sample temp=0.70: 128/128 streams distinct (independent per-slot KV)
+  slot 0: … a robot named Zeta stood at a workbench …
+  slot 1: … Zeta sat in the studio, its mechanical arms splayed …
+  slot 2: … a robot named Zeta whirred to life …
+```
+
+---
+
+## Performance
+
+RTX 4090, Llama-3.2-1B FP16, `ctx=512`, 64 decode steps, CUDA graphs on,
+steady-state (capture steps excluded).
+
+| config | aggregate tok/s | vs single-stream | per-step latency |
+|-------:|----------------:|-----------------:|-----------------:|
+| single-stream (stock decode) | 101 | 1.0× | — |
+| batched B=32  | 1085 | 10.7× | 29.5 ms |
+| batched B=64  | 2167 | 21.5× | 29.5 ms |
+| batched B=128 | **4175** | **41.3×** | 30.7 ms |
+
+CUDA graphs (`-Dbatch.decode.cudaGraphs`, default on) cut a uniform ~6% off per-step
+(dispatch overhead across the 2+N graphs).
+
+**Operating point.** Per-step latency is ~flat (29–31 ms) from B=8 to B=128: every
+step runs at `paddedBatch = 128` (the MMA tile is 128 rows) and the logits GEMM spans
+the full 128256 vocab regardless of B. So B<128 does the same GPU work as B=128
+(wasted pad); aggregate scales ~linearly up to B=128, then per-step grows.
+**B=128 is the efficient operating point.** The residual per-step cost is real GEMM
+compute — full-vocab logits (~33 GFLOP) + 16 layer projections at 128 rows — not
+launch overhead, which is why CUDA graphs help only marginally.
+
+---
+
+## Reproduce
+
+### 1. TornadoVM (CUDA backend + tensor-core MMA)
+
+Requires a TornadoVM with the **CUDA/PTX backend** and the **MMA `KernelContext`**
+API (`mmaFragment` / `mmaLoadA` / `mmaMultiply`, `HalfFloatArray`) — the same
+TornadoVM the `feat/mma_cuda` GPULlama3 branch already needs. Tested against
+**TornadoVM 5.0.1-jdk21-dev** built with the PTX backend on **JDK 21**.
+
+```bash
+git clone https://github.com/beehive-lab/TornadoVM
+cd TornadoVM
+# JDK 21; build the CUDA/PTX backend (installs artifacts into ~/.m2)
+make BACKEND=ptx
+export TORNADOVM_HOME=$PWD/dist/tornadovm-*-cuda
+```
+
+### 2. GPULlama3 (this branch)
+
+```bash
+# JDK 21
+mvn -Pjdk21 -Dtornadovm.base.version=5.0.1 -Djdk.version.suffix=-jdk21-dev \
+    clean package -DskipTests
+```
+
+### 3. Run the engine
+
+`-Dllama.prefillBatchSize` MUST equal `-Dbatch.decode.B` (it sizes the batch
+activation buffers). Launch `org.beehive.gpullama3.bench.BatchedDecodeEngine` on the
+standard TornadoVM module path (easiest: take `llama-tornado --show-command …`,
+swap the main class to the engine, and prepend the `-D` flags):
+
+```
+-Dllama.prefillBatchSize=128     # batch buffers = B
+-Dbatch.decode.B=128             # concurrent sequences
+-Dbatch.decode.ctx=512           # per-slot KV context cap (VRAM)
+-Dbatch.decode.n=64              # decode steps
+-Dbatch.decode.temp=0.0          # 0 = greedy (bit-exact verify); >0 = divergent streams
+-Dbatch.decode.cudaGraphs=true   # CUDA-graph capture/replay
+org.beehive.gpullama3.bench.BatchedDecodeEngine -m <llama-3.2-1b-fp16.gguf> -p "…" --instruct
+```
+
+Two supporting micro-benchmarks (synthetic dims, no model load) isolate the two
+regimes: `bench/BatchedProjectionBench` (compute-bound projection crossover, ~20×)
+and `bench/BatchedDecodeAttentionBench` (memory-bound per-slot attention, ~2×,
+bit-exact vs a CPU reference).
+
+---
+
+## Limitations / next
+
+- **FP16 LLaMA only.** Q8_0 and other architectures reuse the same pattern but need
+  their own decode layer graph. Qwen3 is blocked upstream (empty output on this
+  TornadoVM build) independent of this work.
+- **Same prompt length across slots** (static batching). Ragged prompts / iteration-
+  level (continuous) batching are the follow-up — the per-slot `seqPositions` +
+  per-slot KV base already support per-slot positions.
+- **Logits GEMM over the full vocab every step** is ~half the per-step cost; only
+  needed for slots actually sampling.

--- a/BATCHED_DECODE.md
+++ b/BATCHED_DECODE.md
@@ -287,6 +287,42 @@ for temperature sampling (which still needs logits on the host).
 
 ## Reproduce
 
+### Qwen3 quick start (copy-paste)
+
+After building TornadoVM (CUDA backend) and this project (steps 1–3 below), take
+`llama-tornado --show-command …`, swap the main class to
+`org.beehive.gpullama3.bench.BatchedDecodeEngine`, and prepend the flags. Keep
+`-Dllama.prefillBatchSize` equal to `-Dbatch.decode.B`.
+
+```bash
+# A) static batch — all B streams bit-exact vs single-stream greedy
+-Dllama.prefillBatchSize=32 -Dbatch.decode.B=32 -Dbatch.decode.ctx=512 -Dbatch.decode.n=64 \
+  ... BatchedDecodeEngine -m Qwen3-1.7B-f16.gguf -p "What is the capital of France?" --instruct
+#  → [verify] all 32 streams identical (== single-stream greedy ref): true
+
+# B) continuous multi-request serving — paged KV + prefix cache
+-Dllama.prefillBatchSize=16 -Dbatch.decode.B=16 -Dbatch.decode.ctx=512 -Dbatch.decode.n=64 \
+  -Dbatch.decode.continuous=true -Dbatch.decode.paged=true -Dbatch.decode.prefixCache=true \
+  -Dbatch.decode.requests=128 \
+  ... BatchedDecodeEngine -m Qwen3-1.7B-f16.gguf -p "What is the capital of France?" --instruct
+#  → [verify] 128 requests completed, all mutually prefix-consistent (greedy): true
+```
+
+Verified fresh (RTX 4090, TornadoVM 5.0.1-jdk21-dev, JDK 21) — every row bit-exact /
+prefix-consistent:
+
+| model | mode | throughput | correctness |
+|-------|------|-----------:|-------------|
+| Qwen3-1.7B | static B=8 | 198 tok/s | all streams identical |
+| Qwen3-1.7B | static B=16 | 402 tok/s | all streams identical |
+| Qwen3-1.7B | static B=32 | **801 tok/s** (32×) | all streams identical |
+| Qwen3-1.7B | continuous B=16, R=128, paged+prefix | 301 tok/s · 6.2 req/s · 95.8% util | all prefix-consistent |
+| Qwen3-4B | static B=16 | 217 tok/s | all streams identical |
+| Qwen3-4B | static B=32 | **424 tok/s** (32×) | all streams identical |
+
+Per-stream tok/s stays flat as B grows (1.7B ~25, 4B ~13.5): the MMA tile runs 128
+rows regardless of B, so batching is effectively free until B=128.
+
 ### 1. TornadoVM (CUDA backend + tensor-core MMA)
 
 Requires a TornadoVM with the **CUDA backend** and the **MMA `KernelContext`** API

--- a/BATCHED_DECODE.md
+++ b/BATCHED_DECODE.md
@@ -232,6 +232,28 @@ inactive slots (they still execute the kernels each step) so they never corrupt 
 block. Paging is the prerequisite for prefix caching (share a prompt's blocks across
 requests via the block table + refcounting).
 
+## Prefix caching (`-Dbatch.decode.prefixCache=true`, needs paging)
+
+When requests share a common prompt prefix (a system prompt, a few-shot preamble), its KV
+is identical across all of them. Prefix caching prefills the block-aligned shared prefix
+**once** into pinned blocks; every request points its block-table prefix rows at those
+shared blocks and starts decoding at `pos = sharedPrefixLen`, skipping the prefix's prefill
+entirely. The attention kernel walks the block table, so it reads shared-then-private blocks
+transparently — **no kernel change**, just scheduling + block-table setup.
+
+Same 512-request continuous+paged workload, 48-token shared prompt (Llama-1B, B=128):
+
+| | steps | gen tok/s | requests/s | prefill tokens |
+|--|------:|----------:|-----------:|---------------:|
+| no prefix cache   | 419 | 1307 | 37.2 | 28672 |
+| **prefix cache**  | **211** | **2422** | **69.0** | 4096 (**85.7% saved**) |
+
+**~2× fewer steps, +85% throughput** — the 48-token prefix is prefilled once (3 pinned
+blocks) instead of 512×, and its KV blocks are shared. Output still bit-exact (all completed
+requests mutually prefix-consistent). The win scales with prefix length / request count. The
+prefix is block-aligned down (`sharedPrefixLen = ⌊(promptLen-1)/blockSize⌋·blockSize`) so a
+request only ever writes into its own private blocks; shared blocks stay read-only.
+
 ## Reproduce
 
 ### 1. TornadoVM (CUDA backend + tensor-core MMA)

--- a/BATCHED_DECODE.md
+++ b/BATCHED_DECODE.md
@@ -185,6 +185,28 @@ launch overhead, which is why CUDA graphs help only marginally.
 
 ---
 
+## Continuous batching (iteration-level scheduling)
+
+`-Dbatch.decode.continuous=true` runs an Orca-style scheduler over the same B slots:
+each slot is independently either **prefilling** its prompt (token-by-token, logits
+ignored) or **decoding**; a slot that hits a stop token / its max-gen is evicted and
+**immediately refilled** from a pending queue — new requests join a partly-decoded
+batch mid-flight, so no slot waits for the slowest in a wave. This works with zero
+kernel changes because the per-step forward already feeds one token per slot at its own
+`seqPositions[b]` with its own KV region — prefill and decode are the same op.
+
+Same 512-request workload (Llama-1B, B=128, prompt 22 tok, max-gen ∈ [8,64], greedy —
+so identical token counts and all outputs mutually prefix-consistent):
+
+| scheduling | steps | gen tok/s | requests/s | slot utilization |
+|------------|------:|----------:|-----------:|-----------------:|
+| static wave (`refill=false`) | 336 | 1645 | 46.9 | 66.4% |
+| **continuous** (`refill=true`) | **272** | **1972** | **56.2** | **82.2%** |
+
+**+20% throughput / +24% relative utilization** by refilling freed slots instead of
+draining each wave to its longest request. The gap widens with more length variance.
+Correctness under scheduling = all completed outputs are mutually prefix-consistent.
+
 ## Reproduce
 
 ### 1. TornadoVM (CUDA backend + tensor-core MMA)

--- a/BATCHED_DECODE.md
+++ b/BATCHED_DECODE.md
@@ -314,6 +314,26 @@ regimes: `bench/BatchedProjectionBench` (compute-bound projection crossover, ~20
 and `bench/BatchedDecodeAttentionBench` (memory-bound per-slot attention, ~2×,
 bit-exact vs a CPU reference).
 
+### Exact prompts + flags per result
+
+Prompts (verbatim):
+- `P_SHORT` = `Tell me a short story about a robot learning to paint.`
+- `P_LONG` (48-token shared prefix) = `You are a helpful and knowledgeable assistant. Please write a detailed, vivid and engaging short story about a small curious robot named Zeta who lives in an old cluttered workshop and slowly learns the delicate art of painting with oil colors.`
+
+| result | model | prompt | engine flags |
+|--------|-------|--------|--------------|
+| static B=128 (41×) | llama-1b-fp16 | P_SHORT | `-Dllama.prefillBatchSize=128 -Dbatch.decode.B=128 -Dbatch.decode.ctx=512 -Dbatch.decode.n=64` |
+| divergent streams | llama-1b-fp16 | P_SHORT | above + `-Dbatch.decode.temp=0.7` |
+| continuous (vs static-wave) | llama-1b-fp16 | P_SHORT | `…B=128 -Dbatch.decode.continuous=true -Dbatch.decode.requests=512 -Dbatch.decode.minN=8 -Dbatch.decode.refill=true` (baseline `refill=false`) |
+| paged (10.7× less KV) | llama-1b-fp16 | P_SHORT | `…continuous=true -Dbatch.decode.paged=true -Dbatch.decode.blocks=384 -Dbatch.decode.requests=512 -Dbatch.decode.minN=8` |
+| prefix cache (+85%) | llama-1b-fp16 | P_LONG | `…continuous=true -Dbatch.decode.paged=true -Dbatch.decode.blocks=1024 -Dbatch.decode.prefixCache=true -Dbatch.decode.requests=512 -Dbatch.decode.minN=8` (off: `prefixCache=false`) |
+| Qwen3 paged+prefix (+104%) | Qwen3-1.7B-f16 | P_LONG | `-Dtornado.device.memory=20GB -Dllama.prefillBatchSize=64 -Dbatch.decode.B=64 -Dbatch.decode.ctx=512 -Dbatch.decode.n=64 -Dbatch.decode.continuous=true -Dbatch.decode.paged=true -Dbatch.decode.blocks=768 -Dbatch.decode.prefixCache=true -Dbatch.decode.requests=256 -Dbatch.decode.minN=8` |
+
+All flags (defaults): `batch.decode.B`, `.ctx`(512), `.n`(64), `.temp`(0=greedy),
+`.cudaGraphs`(true), `.continuous`(false), `.refill`(true), `.requests`(4·B), `.minN`(n/2),
+`.paged`(false), `.blockSize`(16), `.blocks`(B·ctx/blockSize), `.prefixCache`(false).
+Each run prints `[verify] …: true` and `[perf] …`.
+
 ---
 
 ## Limitations / next

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeAttentionBench.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeAttentionBench.java
@@ -1,0 +1,188 @@
+package org.beehive.gpullama3.bench;
+
+import org.beehive.gpullama3.tornadovm.kernels.TransformerBatchPrefillKernels;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+
+import java.util.Random;
+
+/**
+ * Standalone validation + benchmark for {@link TransformerBatchPrefillKernels#batchedDecodeAttention}:
+ * B independent sequences each with their own KV cache, one query token each,
+ * every slot attending 0..pos of its own cache. Synthetic Llama-3.2-1B dims (no
+ * model load). Verifies correctness against a CPU reference and reports the
+ * batched attention throughput vs running the same slots one-at-a-time.
+ *
+ * Run: java ... org.beehive.gpullama3.bench.BatchedDecodeAttentionBench [B] [seqLen]
+ */
+public class BatchedDecodeAttentionBench {
+
+    // Llama-3.2-1B geometry.
+    static final int DIM = 2048;
+    static final int N_HEADS = 32;
+    static final int HEAD_SIZE = 64;
+    static final int N_KV_HEADS = 8;
+    static final int KV_DIM = N_KV_HEADS * HEAD_SIZE;   // 512
+    static final int KV_MUL = N_HEADS / N_KV_HEADS;     // 4
+    static final int N_LAYERS = 1;                      // single layer for the microbench
+    static final int CTX = 1024;
+    static final int LAYER = 0;
+    static final int LOCAL = HEAD_SIZE;                 // threads per (slot,head) workgroup
+
+    public static void main(String[] args) throws TornadoExecutionPlanException {
+        int B = args.length > 0 ? Integer.parseInt(args[0]) : 32;
+        int seqLen = args.length > 1 ? Integer.parseInt(args[1]) : 256; // each slot attends 0..seqLen-1
+        int iterations = 100;
+        Random rnd = new Random(42);
+
+        FloatArray q = new FloatArray(B * DIM);
+        FloatArray keyCache = new FloatArray(B * N_LAYERS * CTX * KV_DIM);
+        FloatArray valueCache = new FloatArray(B * N_LAYERS * CTX * KV_DIM);
+        FloatArray xb = new FloatArray(B * DIM);
+        IntArray seqPos = new IntArray(B);
+
+        for (int i = 0; i < B * DIM; i++) {
+            q.set(i, rnd.nextFloat() - 0.5f);
+        }
+        for (int b = 0; b < B; b++) {
+            seqPos.set(b, seqLen - 1);
+            long base = (long) b * N_LAYERS * CTX * KV_DIM;
+            for (int t = 0; t < seqLen; t++) {
+                for (int d = 0; d < KV_DIM; d++) {
+                    keyCache.set((int) (base + (long) t * KV_DIM + d), rnd.nextFloat() - 0.5f);
+                    valueCache.set((int) (base + (long) t * KV_DIM + d), rnd.nextFloat() - 0.5f);
+                }
+            }
+        }
+
+        KernelContext context = new KernelContext();
+        WorkerGrid1D worker = new WorkerGrid1D(B * N_HEADS * LOCAL);
+        worker.setLocalWork(LOCAL, 1, 1);
+        GridScheduler grid = new GridScheduler("bench.attn", worker);
+
+        TaskGraph tg = new TaskGraph("bench") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, q, keyCache, valueCache, seqPos) //
+                .task("attn", TransformerBatchPrefillKernels::batchedDecodeAttention, //
+                        context, seqPos, q, keyCache, valueCache, xb, //
+                        N_HEADS, HEAD_SIZE, KV_DIM, KV_MUL, LAYER, N_LAYERS, CTX, DIM) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, xb);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.withGridScheduler(grid);
+            // warmup
+            for (int i = 0; i < 10; i++) {
+                plan.execute();
+            }
+            // correctness
+            float[] ref = cpuReference(q, keyCache, valueCache, seqPos, B, seqLen);
+            double maxRel = 0.0;
+            int bad = 0;
+            for (int i = 0; i < B * DIM; i++) {
+                float e = ref[i];
+                float a = xb.get(i);
+                double rel = Math.abs(e - a) / Math.max(1e-3, Math.abs(e));
+                maxRel = Math.max(maxRel, rel);
+                if (rel > 2e-2) {
+                    bad++;
+                }
+            }
+            System.out.printf("Batched decode attention: B=%d seqLen=%d  correctness: maxRel=%.4f, out-of-tol=%d/%d%n",
+                    B, seqLen, maxRel, bad, B * DIM);
+
+            long start = System.nanoTime();
+            for (int i = 0; i < iterations; i++) {
+                plan.execute();
+            }
+            double batchedMs = (System.nanoTime() - start) / 1e6 / iterations;
+
+            // Per-slot one-at-a-time (B=1) for comparison.
+            double singleMs = benchSingleSlot(seqLen, iterations);
+            System.out.printf("  batched %d slots: %.4f ms/step  |  1 slot: %.4f ms  |  B*single=%.4f ms%n",
+                    B, batchedMs, singleMs, singleMs * B);
+            System.out.printf("  speedup (B sequential attn -> one batched launch): %.2fx%n", (singleMs * B) / batchedMs);
+        }
+    }
+
+    private static double benchSingleSlot(int seqLen, int iterations) throws TornadoExecutionPlanException {
+        Random rnd = new Random(7);
+        FloatArray q = new FloatArray(DIM);
+        FloatArray keyCache = new FloatArray(N_LAYERS * CTX * KV_DIM);
+        FloatArray valueCache = new FloatArray(N_LAYERS * CTX * KV_DIM);
+        FloatArray xb = new FloatArray(DIM);
+        IntArray seqPos = new IntArray(1);
+        seqPos.set(0, seqLen - 1);
+        for (int i = 0; i < DIM; i++) {
+            q.set(i, rnd.nextFloat() - 0.5f);
+        }
+        for (int i = 0; i < N_LAYERS * CTX * KV_DIM; i++) {
+            keyCache.set(i, rnd.nextFloat() - 0.5f);
+            valueCache.set(i, rnd.nextFloat() - 0.5f);
+        }
+        KernelContext context = new KernelContext();
+        WorkerGrid1D worker = new WorkerGrid1D(N_HEADS * LOCAL);
+        worker.setLocalWork(LOCAL, 1, 1);
+        GridScheduler grid = new GridScheduler("single.attn", worker);
+        TaskGraph tg = new TaskGraph("single") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, q, keyCache, valueCache, seqPos) //
+                .task("attn", TransformerBatchPrefillKernels::batchedDecodeAttention, //
+                        context, seqPos, q, keyCache, valueCache, xb, //
+                        N_HEADS, HEAD_SIZE, KV_DIM, KV_MUL, LAYER, N_LAYERS, CTX, DIM) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, xb);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.withGridScheduler(grid);
+            for (int i = 0; i < 10; i++) {
+                plan.execute();
+            }
+            long start = System.nanoTime();
+            for (int i = 0; i < iterations; i++) {
+                plan.execute();
+            }
+            return (System.nanoTime() - start) / 1e6 / iterations;
+        }
+    }
+
+    private static float[] cpuReference(FloatArray q, FloatArray keyCache, FloatArray valueCache, IntArray seqPos, int B, int seqLen) {
+        float[] out = new float[B * DIM];
+        float scale = (float) (1.0 / Math.sqrt(HEAD_SIZE));
+        for (int b = 0; b < B; b++) {
+            int pos = seqPos.get(b);
+            long base = (long) b * N_LAYERS * CTX * KV_DIM;
+            for (int h = 0; h < N_HEADS; h++) {
+                int kvHead = h / KV_MUL;
+                int qOff = b * DIM + h * HEAD_SIZE;
+                float[] scores = new float[pos + 1];
+                float max = Float.NEGATIVE_INFINITY;
+                for (int t = 0; t <= pos; t++) {
+                    float s = 0.0f;
+                    for (int d = 0; d < HEAD_SIZE; d++) {
+                        s += q.get(qOff + d) * keyCache.get((int) (base + (long) t * KV_DIM + kvHead * HEAD_SIZE + d));
+                    }
+                    s *= scale;
+                    scores[t] = s;
+                    max = Math.max(max, s);
+                }
+                float sum = 0.0f;
+                for (int t = 0; t <= pos; t++) {
+                    scores[t] = (float) Math.exp(scores[t] - max);
+                    sum += scores[t];
+                }
+                float inv = sum > 0 ? 1.0f / sum : 0.0f;
+                for (int d = 0; d < HEAD_SIZE; d++) {
+                    float acc = 0.0f;
+                    for (int t = 0; t <= pos; t++) {
+                        acc += scores[t] * inv * valueCache.get((int) (base + (long) t * KV_DIM + kvHead * HEAD_SIZE + d));
+                    }
+                    out[qOff + d] = acc;
+                }
+            }
+        }
+        return out;
+    }
+}

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
@@ -2,12 +2,17 @@ package org.beehive.gpullama3.bench;
 
 import org.beehive.gpullama3.Options;
 import org.beehive.gpullama3.inference.state.LlamaState;
+import org.beehive.gpullama3.inference.state.State;
 import org.beehive.gpullama3.inference.weights.tornado.LlamaTornadoWeights;
+import org.beehive.gpullama3.inference.weights.tornado.TornadoWeights;
+import org.beehive.gpullama3.model.Configuration;
 import org.beehive.gpullama3.model.Model;
 import org.beehive.gpullama3.model.format.ChatFormat;
 import org.beehive.gpullama3.model.llama.LlamaConfiguration;
+import org.beehive.gpullama3.model.qwen3.Qwen3Configuration;
 import org.beehive.gpullama3.tornadovm.kernels.TransformerBatchPrefillKernels;
 import org.beehive.gpullama3.tornadovm.layers.type.fp16.decode.LlamaFP16LayersBatchDecodeMMA;
+import org.beehive.gpullama3.tornadovm.layers.type.fp16.decode.Qwen3FP16LayersBatchDecodeMMA;
 import org.beehive.gpullama3.tornadovm.plan.components.activation.BatchPrefillActivation;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
@@ -68,14 +73,17 @@ public class BatchedDecodeEngine {
 
         Options options = Options.parseOptions(args);
         Model model = loadModel(options);
-        LlamaConfiguration config = (LlamaConfiguration) model.configuration();
-        LlamaTornadoWeights weights = (LlamaTornadoWeights) model.weights();
-        LlamaState state = (LlamaState) model.createNewState();
+        Configuration config = model.configuration();
+        TornadoWeights weights = (TornadoWeights) model.weights();
+        State state = model.createNewState();
+        boolean isQwen3 = config instanceof Qwen3Configuration;
 
         int dim = config.dim();
         int vocab = config.vocabularySize();
-        int kvDim = config.kvDim();
         int numLayers = config.numberOfLayers();
+        int kvDim = isQwen3
+                ? ((Qwen3Configuration) config).numberOfHeadsValue() * config.numberOfKeyValueHeads()
+                : (config.dim() * config.numberOfKeyValueHeads()) / config.numberOfHeads();
         int paddedB = (B + 127) & ~127;
 
         // ── Prompt tokens ──────────────────────────────────────────────────────
@@ -108,13 +116,31 @@ public class BatchedDecodeEngine {
 
         // ── Graphs: [0] activation, [1..N] decode layers, [N+1] batched logits ──
         BatchPrefillActivation activation = new BatchPrefillActivation(state, config, B, false);
-        LlamaFP16LayersBatchDecodeMMA layers = new LlamaFP16LayersBatchDecodeMMA(
-                state, weights, config, B, decodeCtx, keyCacheBatch, valueCacheBatch, seqPositions);
+
+        List<ImmutableTaskGraph> layerITGs;
+        String lastLayerId;
+        java.util.function.Consumer<GridScheduler> updateLayerSched;
+        if (isQwen3) {
+            Qwen3FP16LayersBatchDecodeMMA q = new Qwen3FP16LayersBatchDecodeMMA(
+                    (org.beehive.gpullama3.inference.state.Qwen3State) state,
+                    (org.beehive.gpullama3.inference.weights.tornado.Qwen3TornadoWeights) weights,
+                    (Qwen3Configuration) config, B, decodeCtx, keyCacheBatch, valueCacheBatch, seqPositions);
+            layerITGs = q.getLayerImmutableTaskGraphs();
+            lastLayerId = q.getLastLayerTaskGraphID();
+            updateLayerSched = q::updateGridScheduler;
+        } else {
+            LlamaFP16LayersBatchDecodeMMA l = new LlamaFP16LayersBatchDecodeMMA(
+                    (LlamaState) state,
+                    (LlamaTornadoWeights) weights,
+                    (LlamaConfiguration) config, B, decodeCtx, keyCacheBatch, valueCacheBatch, seqPositions);
+            layerITGs = l.getLayerImmutableTaskGraphs();
+            lastLayerId = l.getLastLayerTaskGraphID();
+            updateLayerSched = l::updateGridScheduler;
+        }
 
         KernelContext logitsCtx = new KernelContext();
         HalfFloatArray wclsHalf = weights.wclsByteArray.asHalfFloatArray();
         FloatArray rmsFinal = weights.rms_final_weight_as_floatArray.asFloatArray();
-        String lastLayerId = layers.getLastLayerTaskGraphID();
         TaskGraph logitsTg = new TaskGraph("batchLogits")
                 .consumeFromDevice(lastLayerId, state.wrapXBatch)
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION,
@@ -131,16 +157,16 @@ public class BatchedDecodeEngine {
         // ── Grid scheduler ──────────────────────────────────────────────────────
         GridScheduler gs = new GridScheduler();
         activation.updateGridScheduler(gs);
-        layers.updateGridScheduler(gs);
+        updateLayerSched.accept(gs);
         gs.addWorkerGrid("batchLogits.rms_reduce", genericWorker(B * RMS_LOCAL, RMS_LOCAL));
         gs.addWorkerGrid("batchLogits.rms_apply", genericWorker(B * dim, 256));
         gs.addWorkerGrid("batchLogits.vocab", mmaGrid(paddedB, vocab));
 
         List<ImmutableTaskGraph> all = new ArrayList<>();
         all.add(activation.getImmutableTaskGraph());
-        all.addAll(layers.getLayerImmutableTaskGraphs());
+        all.addAll(layerITGs);
         all.add(logitsItg);
-        int nLayers = layers.getLayerImmutableTaskGraphs().size();
+        int nLayers = layerITGs.size();
         int logitsIdx = 1 + nLayers;
 
         MemorySegment embTable = weights.getTokenEmbeddingTable().asHalfFloatArray().getSegment();

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
@@ -132,6 +132,11 @@ public class BatchedDecodeEngine {
         HalfFloatArray normedFinalFP16 = new HalfFloatArray(paddedB * dim);
         normedFinalFP16.init(new uk.ac.manchester.tornado.api.types.HalfFloat(0.0f));
         FloatArray logitsBatch = new FloatArray(paddedB * vocab);
+        // On-device greedy: argmax on the GPU, transfer only B token ids (not the
+        // 65–78 MB logits tensor). Falls back to host path for temperature sampling.
+        boolean deviceSample = Boolean.parseBoolean(System.getProperty("batch.decode.deviceSample", "true"))
+                && Float.parseFloat(System.getProperty("batch.decode.temp", "0.0")) == 0.0f;
+        IntArray sampledTokens = new IntArray(paddedB);
 
         // ── Graphs: [0] activation, [1..N] decode layers, [N+1] batched logits ──
         BatchPrefillActivation activation = new BatchPrefillActivation(state, config, B, false);
@@ -174,8 +179,15 @@ public class BatchedDecodeEngine {
                 .task("rms_apply", TransformerBatchPrefillKernels::batchedFFNRmsApplyFP16,
                         logitsCtx, normedFinalFP16, state.wrapXBatch, rmsFinal, finalScaleBatch, dim)
                 .task("vocab", TransformerBatchPrefillKernels::gemmMMA,
-                        logitsCtx, normedFinalFP16, wclsHalf, logitsBatch, paddedB, vocab, dim)
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, logitsBatch);
+                        logitsCtx, normedFinalFP16, wclsHalf, logitsBatch, paddedB, vocab, dim);
+        if (deviceSample) {                                    // argmax on GPU → transfer only B ids
+            logitsTg.transferToDevice(DataTransferMode.FIRST_EXECUTION, sampledTokens)
+                    .task("argmax", TransformerBatchPrefillKernels::batchedArgmaxLogits,
+                            logitsCtx, logitsBatch, sampledTokens, vocab)
+                    .transferToHost(DataTransferMode.EVERY_EXECUTION, sampledTokens);
+        } else {
+            logitsTg.transferToHost(DataTransferMode.EVERY_EXECUTION, logitsBatch);
+        }
         ImmutableTaskGraph logitsItg = logitsTg.snapshot();
 
         // ── Grid scheduler ──────────────────────────────────────────────────────
@@ -185,6 +197,9 @@ public class BatchedDecodeEngine {
         gs.addWorkerGrid("batchLogits.rms_reduce", genericWorker(B * RMS_LOCAL, RMS_LOCAL));
         gs.addWorkerGrid("batchLogits.rms_apply", genericWorker(B * dim, 256));
         gs.addWorkerGrid("batchLogits.vocab", mmaGrid(paddedB, vocab));
+        if (deviceSample) {
+            gs.addWorkerGrid("batchLogits.argmax", genericWorker(B * 256, 256));
+        }
 
         List<ImmutableTaskGraph> all = new ArrayList<>();
         all.add(activation.getImmutableTaskGraph());
@@ -201,7 +216,8 @@ public class BatchedDecodeEngine {
             if (Boolean.parseBoolean(System.getProperty("batch.decode.continuous", "false"))) {
                 runContinuous(plan, gs, nLayers, logitsIdx, cudaGraphs, model, B, dim, vocab, nDecode,
                         prompt, stopTokens, embTable, dimBytes, state.embeddingXBatch.getSegment(),
-                        seqPositions, logitsBatch, paged, blockTable, blockSize, maxBlocksPerSlot, numBlocks);
+                        seqPositions, logitsBatch, paged, blockTable, blockSize, maxBlocksPerSlot, numBlocks,
+                        deviceSample, sampledTokens);
                 return;
             }
 
@@ -236,7 +252,7 @@ public class BatchedDecodeEngine {
             int[] cur = new int[B];
             for (int b = 0; b < B; b++) {
                 int first = sample ? sampleRow(logitsBatch, b, vocab, temperature, rng[b])
-                                   : argmaxRow(logitsBatch, b, vocab);
+                                   : (deviceSample ? sampledTokens.get(b) : argmaxRow(logitsBatch, b, vocab));
                 cur[b] = first;
                 streams[b][0] = first;
             }
@@ -262,7 +278,7 @@ public class BatchedDecodeEngine {
                 }
                 for (int b = 0; b < B; b++) {
                     int nt = sample ? sampleRow(logitsBatch, b, vocab, temperature, rng[b])
-                                    : argmaxRow(logitsBatch, b, vocab);
+                                    : (deviceSample ? sampledTokens.get(b) : argmaxRow(logitsBatch, b, vocab));
                     cur[b] = nt;
                     streams[b][s] = nt;
                 }
@@ -324,7 +340,8 @@ public class BatchedDecodeEngine {
                                       List<Integer> prompt, java.util.Set<Integer> stopTokens,
                                       MemorySegment embTable, long dimBytes, MemorySegment embBatchSeg,
                                       IntArray seqPositions, FloatArray logitsBatch,
-                                      boolean paged, IntArray blockTable, int blockSize, int maxBlocksPerSlot, int numBlocks) {
+                                      boolean paged, IntArray blockTable, int blockSize, int maxBlocksPerSlot, int numBlocks,
+                                      boolean deviceSample, IntArray sampledTokens) {
         int R = Integer.getInteger("batch.decode.requests", 4 * B);
         int minN = Integer.getInteger("batch.decode.minN", Math.max(1, nDecode / 2));
         boolean refill = Boolean.parseBoolean(System.getProperty("batch.decode.refill", "true"));
@@ -487,14 +504,14 @@ public class BatchedDecodeEngine {
                 if (!decoding[b]) {
                     prefillTokens++;
                     if (promptPos[b] == promptLen - 1) {
-                        nt = argmaxRow(logitsBatch, b, vocab);
+                        nt = deviceSample ? sampledTokens.get(b) : argmaxRow(logitsBatch, b, vocab);
                         decoding[b] = true;
                         produced = true;
                     } else {
                         promptPos[b]++;
                     }
                 } else {
-                    nt = argmaxRow(logitsBatch, b, vocab);
+                    nt = deviceSample ? sampledTokens.get(b) : argmaxRow(logitsBatch, b, vocab);
                     produced = true;
                 }
                 if (produced) {

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
@@ -389,7 +389,7 @@ public class BatchedDecodeEngine {
         }
 
         int warm = cudaGraphs ? 4 : 0;
-        long steps = 0, genTokens = 0, timedNs = 0, timedGen = 0, timedBusy = 0, timedSteps = 0, prefillTokens = 0;
+        long steps = 0, genTokens = 0, timedNs = 0, timedGen = 0, timedBusy = 0, timedSteps = 0, prefillTokens = 0, logitsSkipped = 0;
         long tTimed = 0;
         while (true) {
             // ── Admission (single site) ──────────────────────────────────────────
@@ -456,8 +456,22 @@ public class BatchedDecodeEngine {
                 }
             }
 
+            // Logits are only needed by slots that SAMPLE this step: any decoding slot,
+            // or a prefill slot feeding its last prompt token. If a whole step is pure
+            // prefill (common with long prompts), skip the full-vocab logits GEMM.
+            boolean needLogits = false;
+            for (int b = 0; b < B; b++) {
+                if (active[b] && (decoding[b] || promptPos[b] == promptLen - 1)) {
+                    needLogits = true;
+                    break;
+                }
+            }
+            if (!needLogits) {
+                logitsSkipped++;
+            }
+
             long t0 = System.nanoTime();
-            runStep(plan, gs, nLayers, logitsIdx, true, cudaGraphs);
+            runStep(plan, gs, nLayers, logitsIdx, needLogits, cudaGraphs);
             long dt = System.nanoTime() - t0;
             steps++;
 
@@ -537,7 +551,8 @@ public class BatchedDecodeEngine {
 
         double sec = wallNs / 1e9;
         double util = timedSteps > 0 ? (double) timedBusy / (timedSteps * B) : 0.0;
-        System.out.printf("[perf] continuous: %d steps, %d gen tokens over %.2f s%n", steps, genTokens, sec);
+        System.out.printf("[perf] continuous: %d steps (%d logits-skipped, %.0f%%), %d gen tokens over %.2f s%n",
+                steps, logitsSkipped, 100.0 * logitsSkipped / Math.max(1, steps), genTokens, sec);
         System.out.printf("[perf] generated %.0f tok/s | %.1f requests/s | slot utilization %.1f%% | per-step %.2f ms%n",
                 timedGen / sec, completed.size() / (wallNs / 1e9), util * 100.0,
                 timedSteps > 0 ? timedNs / 1e6 / timedSteps : 0.0);

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
@@ -327,14 +327,19 @@ public class BatchedDecodeEngine {
                                       boolean paged, IntArray blockTable, int blockSize, int maxBlocksPerSlot, int numBlocks) {
         int R = Integer.getInteger("batch.decode.requests", 4 * B);
         int minN = Integer.getInteger("batch.decode.minN", Math.max(1, nDecode / 2));
-        // refill=true → continuous (admit into a freed slot immediately);
-        // refill=false → static-wave baseline (idle until the whole wave finishes, then reload).
         boolean refill = Boolean.parseBoolean(System.getProperty("batch.decode.refill", "true"));
+        // Prefix caching: the shared prompt prefix (block-aligned) is prefilled ONCE into
+        // pinned blocks; every request points its block-table prefix rows at them and
+        // starts at pos = sharedPrefixLen — skipping the prefix's prefill entirely.
+        boolean prefixCache = paged && Boolean.parseBoolean(System.getProperty("batch.decode.prefixCache", "false"));
         int promptLen = prompt.size();
+        int sharedPrefixLen = prefixCache ? ((promptLen - 1) / blockSize) * blockSize : 0;
+        int prefixBlocks = sharedPrefixLen / blockSize;
 
-        // Paged KV block allocator: free list of physical blocks + per-slot held blocks.
         java.util.ArrayDeque<Integer> freeBlocks = new java.util.ArrayDeque<>();
-        List<List<Integer>> slotBlocks = new ArrayList<>();
+        List<List<Integer>> slotBlocks = new ArrayList<>();  // PRIVATE blocks per slot (freed on evict)
+        int[] allocedUpTo = new int[B];                       // highest logical block mapped for a slot
+        int[] sharedBlocks = new int[Math.max(1, prefixBlocks)];
         int peakBlocks = 0;
         if (paged) {
             for (int i = 0; i < numBlocks; i++) {
@@ -344,13 +349,6 @@ public class BatchedDecodeEngine {
                 slotBlocks.add(new ArrayList<>());
             }
         }
-        java.util.Random wl = new java.util.Random(7);
-        java.util.ArrayDeque<Integer> queue = new java.util.ArrayDeque<>();
-        for (int i = 0; i < R; i++) {
-            queue.add(minN + wl.nextInt(Math.max(1, nDecode - minN + 1)));
-        }
-        System.out.printf("[continuous] requests=%d maxGen∈[%d,%d] B=%d%n", R, minN, nDecode, B);
-
         int[] promptPos = new int[B], pos = new int[B], curTok = new int[B], maxGen = new int[B];
         boolean[] decoding = new boolean[B], active = new boolean[B];
         List<List<Integer>> gen = new ArrayList<>();
@@ -358,59 +356,106 @@ public class BatchedDecodeEngine {
             gen.add(new ArrayList<>());
         }
         List<int[]> completed = new ArrayList<>();
-        for (int b = 0; b < B; b++) {
-            if (!queue.isEmpty()) {
-                maxGen[b] = queue.poll();
-                active[b] = true;
+
+        java.util.Random wl = new java.util.Random(7);
+        java.util.ArrayDeque<Integer> queue = new java.util.ArrayDeque<>();
+        for (int i = 0; i < R; i++) {
+            queue.add(minN + wl.nextInt(Math.max(1, nDecode - minN + 1)));
+        }
+        System.out.printf("[continuous] requests=%d maxGen∈[%d,%d] B=%d%s%n", R, minN, nDecode, B,
+                prefixCache ? " prefixCache sharedPrefix=" + sharedPrefixLen + " tok" : "");
+
+        // ── One-time shared-prefix prefill into pinned blocks ────────────────────
+        if (prefixCache && sharedPrefixLen > 0) {
+            for (int lb = 0; lb < prefixBlocks; lb++) {
+                sharedBlocks[lb] = freeBlocks.poll();          // pinned: never returned
+                blockTable.set(0 * maxBlocksPerSlot + lb, sharedBlocks[lb]);
+            }
+            for (int b = 1; b < B; b++) {
+                blockTable.set(b * maxBlocksPerSlot, numBlocks);  // scratch
+            }
+            for (int t = 0; t < sharedPrefixLen; t++) {
+                int tok = prompt.get(t);
+                MemorySegment.copy(embTable, (long) tok * dimBytes, embBatchSeg, 0L, dimBytes);
+                for (int b = 1; b < B; b++) {
+                    MemorySegment.copy(embTable, (long) prompt.get(0) * dimBytes, embBatchSeg, (long) b * dimBytes, dimBytes);
+                }
+                seqPositions.set(0, t);
+                for (int b = 1; b < B; b++) {
+                    seqPositions.set(b, 0);
+                }
+                runStep(plan, gs, nLayers, logitsIdx, false, cudaGraphs);
             }
         }
 
         int warm = cudaGraphs ? 4 : 0;
-        long steps = 0, genTokens = 0, busySlotSteps = 0, timedNs = 0, timedGen = 0, timedBusy = 0, timedSteps = 0;
+        long steps = 0, genTokens = 0, timedNs = 0, timedGen = 0, timedBusy = 0, timedSteps = 0, prefillTokens = 0;
         long tTimed = 0;
         while (true) {
+            // ── Admission (single site) ──────────────────────────────────────────
             boolean anyActive = false;
             for (int b = 0; b < B; b++) {
                 if (active[b]) { anyActive = true; break; }
             }
-            if (!anyActive) {
-                if (queue.isEmpty()) {
-                    break;
-                }
-                // static-wave baseline: whole wave drained → load the next wave.
+            boolean admitNow = refill || !anyActive;   // continuous: fill any gap; static-wave: only whole new wave
+            if (admitNow) {
                 for (int b = 0; b < B; b++) {
-                    if (!queue.isEmpty()) {
+                    if (!active[b] && !queue.isEmpty()) {
                         maxGen[b] = queue.poll();
-                        promptPos[b] = 0;
-                        pos[b] = 0;
-                        decoding[b] = false;
+                        gen.get(b).clear();
                         active[b] = true;
+                        decoding[b] = false;
+                        if (paged) {
+                            slotBlocks.get(b).clear();
+                        }
+                        if (prefixCache && sharedPrefixLen > 0) {   // reuse the shared prefix
+                            for (int lb = 0; lb < prefixBlocks; lb++) {
+                                blockTable.set(b * maxBlocksPerSlot + lb, sharedBlocks[lb]);
+                            }
+                            allocedUpTo[b] = prefixBlocks - 1;
+                            promptPos[b] = sharedPrefixLen;
+                            pos[b] = sharedPrefixLen;
+                        } else {
+                            allocedUpTo[b] = -1;
+                            promptPos[b] = 0;
+                            pos[b] = 0;
+                        }
                     }
                 }
             }
+            anyActive = false;
+            for (int b = 0; b < B; b++) {
+                if (active[b]) { anyActive = true; break; }
+            }
+            if (!anyActive) {
+                break;
+            }
+
+            // ── Fill embeddings + positions + block allocation ───────────────────
             for (int b = 0; b < B; b++) {
                 int tok = active[b] ? (decoding[b] ? curTok[b] : prompt.get(promptPos[b])) : prompt.get(0);
                 MemorySegment.copy(embTable, (long) tok * dimBytes, embBatchSeg, (long) b * dimBytes, dimBytes);
                 seqPositions.set(b, active[b] ? pos[b] : 0);
                 if (paged) {
-                    if (active[b]) {                               // ensure a physical block for this position
+                    if (active[b]) {
                         int lb = pos[b] / blockSize;
-                        List<Integer> sb = slotBlocks.get(b);
-                        while (sb.size() <= lb) {
+                        while (allocedUpTo[b] < lb) {
                             if (freeBlocks.isEmpty()) {
                                 throw new IllegalStateException("KV block pool exhausted (" + numBlocks
                                         + "); raise -Dbatch.decode.blocks");
                             }
                             int phys = freeBlocks.poll();
-                            blockTable.set(b * maxBlocksPerSlot + sb.size(), phys);
-                            sb.add(phys);
+                            allocedUpTo[b]++;
+                            blockTable.set(b * maxBlocksPerSlot + allocedUpTo[b], phys);
+                            slotBlocks.get(b).add(phys);
                             peakBlocks = Math.max(peakBlocks, numBlocks - freeBlocks.size());
                         }
-                    } else {                                       // inactive slot dumps into the scratch block
-                        blockTable.set(b * maxBlocksPerSlot, numBlocks);
+                    } else {
+                        blockTable.set(b * maxBlocksPerSlot, numBlocks);  // inactive → scratch
                     }
                 }
             }
+
             long t0 = System.nanoTime();
             runStep(plan, gs, nLayers, logitsIdx, true, cudaGraphs);
             long dt = System.nanoTime() - t0;
@@ -426,7 +471,8 @@ public class BatchedDecodeEngine {
                 boolean produced = false;
                 int nt = 0;
                 if (!decoding[b]) {
-                    if (promptPos[b] == promptLen - 1) {          // just fed the last prompt token
+                    prefillTokens++;
+                    if (promptPos[b] == promptLen - 1) {
                         nt = argmaxRow(logitsBatch, b, vocab);
                         decoding[b] = true;
                         produced = true;
@@ -445,23 +491,14 @@ public class BatchedDecodeEngine {
                     boolean stop = stopTokens.contains(nt) || gen.get(b).size() >= maxGen[b];
                     if (stop) {
                         completed.add(gen.get(b).stream().mapToInt(Integer::intValue).toArray());
-                        gen.get(b).clear();
-                        if (paged) {                               // return this request's blocks to the pool
+                        if (paged) {                               // free PRIVATE blocks only (prefix is pinned)
                             freeBlocks.addAll(slotBlocks.get(b));
                             slotBlocks.get(b).clear();
                         }
-                        if (refill && !queue.isEmpty()) {          // continuous: admit next request now
-                            maxGen[b] = queue.poll();
-                            promptPos[b] = 0;
-                            pos[b] = 0;
-                            decoding[b] = false;
-                        } else {                                    // static-wave: idle until wave ends
-                            active[b] = false;
-                        }
+                        active[b] = false;
                     }
                 }
             }
-            busySlotSteps += stepBusy;
             if (steps > warm) {
                 if (timedSteps == 0) {
                     tTimed = System.nanoTime();
@@ -507,6 +544,12 @@ public class BatchedDecodeEngine {
         if (paged) {
             System.out.printf("[paged] peak blocks in use %d / %d pool (%.0f%%); full contiguous reservation would need %d%n",
                     peakBlocks, numBlocks, 100.0 * peakBlocks / numBlocks, B * maxBlocksPerSlot);
+        }
+        if (prefixCache && sharedPrefixLen > 0) {
+            long prefillNoCache = (long) R * promptLen;
+            System.out.printf("[prefix] shared prefix %d tok prefilled once (%d blocks pinned); prefill tokens %d vs %d without cache (%.1f%% saved)%n",
+                    sharedPrefixLen, prefixBlocks, prefillTokens, prefillNoCache,
+                    100.0 * (prefillNoCache - prefillTokens) / prefillNoCache);
         }
     }
 

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
@@ -112,9 +112,6 @@ public class BatchedDecodeEngine {
         IntArray blockTable = null;
         long kvElems;
         if (paged) {
-            if (isQwen3) {
-                throw new IllegalStateException("paged KV currently wired for LLaMA only");
-            }
             // +1 scratch block: inactive slots still execute the KV kernels every step,
             // so they must dump into a reserved block, never a live one.
             kvElems = (long) (numBlocks + 1) * numLayers * blockSize * kvDim;
@@ -143,10 +140,13 @@ public class BatchedDecodeEngine {
         String lastLayerId;
         java.util.function.Consumer<GridScheduler> updateLayerSched;
         if (isQwen3) {
-            Qwen3FP16LayersBatchDecodeMMA q = new Qwen3FP16LayersBatchDecodeMMA(
-                    (org.beehive.gpullama3.inference.state.Qwen3State) state,
-                    (org.beehive.gpullama3.inference.weights.tornado.Qwen3TornadoWeights) weights,
-                    (Qwen3Configuration) config, B, decodeCtx, keyCacheBatch, valueCacheBatch, seqPositions);
+            var qState = (org.beehive.gpullama3.inference.state.Qwen3State) state;
+            var qWeights = (org.beehive.gpullama3.inference.weights.tornado.Qwen3TornadoWeights) weights;
+            Qwen3FP16LayersBatchDecodeMMA q = paged
+                    ? new Qwen3FP16LayersBatchDecodeMMA(qState, qWeights, (Qwen3Configuration) config, B, decodeCtx,
+                        keyCacheBatch, valueCacheBatch, seqPositions, blockTable, blockSize, maxBlocksPerSlot)
+                    : new Qwen3FP16LayersBatchDecodeMMA(qState, qWeights, (Qwen3Configuration) config, B, decodeCtx,
+                        keyCacheBatch, valueCacheBatch, seqPositions);
             layerITGs = q.getLayerImmutableTaskGraphs();
             lastLayerId = q.getLastLayerTaskGraphID();
             updateLayerSched = q::updateGridScheduler;

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
@@ -103,7 +103,29 @@ public class BatchedDecodeEngine {
                 B, decodeCtx, P, nDecode, dim, vocab, numLayers, cudaGraphs);
 
         // ── Engine-owned buffers ────────────────────────────────────────────────
-        long kvElems = (long) B * numLayers * decodeCtx * kvDim;
+        // Paged: KV is a shared pool of fixed-size blocks addressed via a per-slot
+        // block table, so the pool can be smaller than the B×ctx contiguous cache.
+        boolean paged = Boolean.parseBoolean(System.getProperty("batch.decode.paged", "false"));
+        int blockSize = Integer.getInteger("batch.decode.blockSize", 16);
+        int maxBlocksPerSlot = (decodeCtx + blockSize - 1) / blockSize;
+        int numBlocks = Integer.getInteger("batch.decode.blocks", B * maxBlocksPerSlot);
+        IntArray blockTable = null;
+        long kvElems;
+        if (paged) {
+            if (isQwen3) {
+                throw new IllegalStateException("paged KV currently wired for LLaMA only");
+            }
+            // +1 scratch block: inactive slots still execute the KV kernels every step,
+            // so they must dump into a reserved block, never a live one.
+            kvElems = (long) (numBlocks + 1) * numLayers * blockSize * kvDim;
+            blockTable = new IntArray(B * maxBlocksPerSlot);
+            blockTable.init(numBlocks);   // point everything at the scratch block initially
+            System.out.printf("[paged] blockSize=%d blocks=%d (=%d MB pool) vs contiguous %d MB; maxBlocks/slot=%d%n",
+                    blockSize, numBlocks, (kvElems * 2 * 4) >> 20,
+                    ((long) B * numLayers * decodeCtx * kvDim * 2 * 4) >> 20, maxBlocksPerSlot);
+        } else {
+            kvElems = (long) B * numLayers * decodeCtx * kvDim;
+        }
         FloatArray keyCacheBatch = new FloatArray((int) kvElems);
         FloatArray valueCacheBatch = new FloatArray((int) kvElems);
         keyCacheBatch.init(0.0f);
@@ -129,10 +151,12 @@ public class BatchedDecodeEngine {
             lastLayerId = q.getLastLayerTaskGraphID();
             updateLayerSched = q::updateGridScheduler;
         } else {
-            LlamaFP16LayersBatchDecodeMMA l = new LlamaFP16LayersBatchDecodeMMA(
-                    (LlamaState) state,
-                    (LlamaTornadoWeights) weights,
-                    (LlamaConfiguration) config, B, decodeCtx, keyCacheBatch, valueCacheBatch, seqPositions);
+            LlamaFP16LayersBatchDecodeMMA l = paged
+                    ? new LlamaFP16LayersBatchDecodeMMA((LlamaState) state, (LlamaTornadoWeights) weights,
+                        (LlamaConfiguration) config, B, decodeCtx, keyCacheBatch, valueCacheBatch, seqPositions,
+                        blockTable, blockSize, maxBlocksPerSlot)
+                    : new LlamaFP16LayersBatchDecodeMMA((LlamaState) state, (LlamaTornadoWeights) weights,
+                        (LlamaConfiguration) config, B, decodeCtx, keyCacheBatch, valueCacheBatch, seqPositions);
             layerITGs = l.getLayerImmutableTaskGraphs();
             lastLayerId = l.getLastLayerTaskGraphID();
             updateLayerSched = l::updateGridScheduler;
@@ -177,7 +201,7 @@ public class BatchedDecodeEngine {
             if (Boolean.parseBoolean(System.getProperty("batch.decode.continuous", "false"))) {
                 runContinuous(plan, gs, nLayers, logitsIdx, cudaGraphs, model, B, dim, vocab, nDecode,
                         prompt, stopTokens, embTable, dimBytes, state.embeddingXBatch.getSegment(),
-                        seqPositions, logitsBatch);
+                        seqPositions, logitsBatch, paged, blockTable, blockSize, maxBlocksPerSlot, numBlocks);
                 return;
             }
 
@@ -299,13 +323,27 @@ public class BatchedDecodeEngine {
                                       boolean cudaGraphs, Model model, int B, int dim, int vocab, int nDecode,
                                       List<Integer> prompt, java.util.Set<Integer> stopTokens,
                                       MemorySegment embTable, long dimBytes, MemorySegment embBatchSeg,
-                                      IntArray seqPositions, FloatArray logitsBatch) {
+                                      IntArray seqPositions, FloatArray logitsBatch,
+                                      boolean paged, IntArray blockTable, int blockSize, int maxBlocksPerSlot, int numBlocks) {
         int R = Integer.getInteger("batch.decode.requests", 4 * B);
         int minN = Integer.getInteger("batch.decode.minN", Math.max(1, nDecode / 2));
         // refill=true → continuous (admit into a freed slot immediately);
         // refill=false → static-wave baseline (idle until the whole wave finishes, then reload).
         boolean refill = Boolean.parseBoolean(System.getProperty("batch.decode.refill", "true"));
         int promptLen = prompt.size();
+
+        // Paged KV block allocator: free list of physical blocks + per-slot held blocks.
+        java.util.ArrayDeque<Integer> freeBlocks = new java.util.ArrayDeque<>();
+        List<List<Integer>> slotBlocks = new ArrayList<>();
+        int peakBlocks = 0;
+        if (paged) {
+            for (int i = 0; i < numBlocks; i++) {
+                freeBlocks.add(i);
+            }
+            for (int b = 0; b < B; b++) {
+                slotBlocks.add(new ArrayList<>());
+            }
+        }
         java.util.Random wl = new java.util.Random(7);
         java.util.ArrayDeque<Integer> queue = new java.util.ArrayDeque<>();
         for (int i = 0; i < R; i++) {
@@ -354,6 +392,24 @@ public class BatchedDecodeEngine {
                 int tok = active[b] ? (decoding[b] ? curTok[b] : prompt.get(promptPos[b])) : prompt.get(0);
                 MemorySegment.copy(embTable, (long) tok * dimBytes, embBatchSeg, (long) b * dimBytes, dimBytes);
                 seqPositions.set(b, active[b] ? pos[b] : 0);
+                if (paged) {
+                    if (active[b]) {                               // ensure a physical block for this position
+                        int lb = pos[b] / blockSize;
+                        List<Integer> sb = slotBlocks.get(b);
+                        while (sb.size() <= lb) {
+                            if (freeBlocks.isEmpty()) {
+                                throw new IllegalStateException("KV block pool exhausted (" + numBlocks
+                                        + "); raise -Dbatch.decode.blocks");
+                            }
+                            int phys = freeBlocks.poll();
+                            blockTable.set(b * maxBlocksPerSlot + sb.size(), phys);
+                            sb.add(phys);
+                            peakBlocks = Math.max(peakBlocks, numBlocks - freeBlocks.size());
+                        }
+                    } else {                                       // inactive slot dumps into the scratch block
+                        blockTable.set(b * maxBlocksPerSlot, numBlocks);
+                    }
+                }
             }
             long t0 = System.nanoTime();
             runStep(plan, gs, nLayers, logitsIdx, true, cudaGraphs);
@@ -390,6 +446,10 @@ public class BatchedDecodeEngine {
                     if (stop) {
                         completed.add(gen.get(b).stream().mapToInt(Integer::intValue).toArray());
                         gen.get(b).clear();
+                        if (paged) {                               // return this request's blocks to the pool
+                            freeBlocks.addAll(slotBlocks.get(b));
+                            slotBlocks.get(b).clear();
+                        }
                         if (refill && !queue.isEmpty()) {          // continuous: admit next request now
                             maxGen[b] = queue.poll();
                             promptPos[b] = 0;
@@ -444,6 +504,10 @@ public class BatchedDecodeEngine {
         System.out.printf("[perf] generated %.0f tok/s | %.1f requests/s | slot utilization %.1f%% | per-step %.2f ms%n",
                 timedGen / sec, completed.size() / (wallNs / 1e9), util * 100.0,
                 timedSteps > 0 ? timedNs / 1e6 / timedSteps : 0.0);
+        if (paged) {
+            System.out.printf("[paged] peak blocks in use %d / %d pool (%.0f%%); full contiguous reservation would need %d%n",
+                    peakBlocks, numBlocks, 100.0 * peakBlocks / numBlocks, B * maxBlocksPerSlot);
+        }
     }
 
     private static void runStep(TornadoExecutionPlan plan, GridScheduler gs,

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
@@ -1,0 +1,336 @@
+package org.beehive.gpullama3.bench;
+
+import org.beehive.gpullama3.Options;
+import org.beehive.gpullama3.inference.state.LlamaState;
+import org.beehive.gpullama3.inference.weights.tornado.LlamaTornadoWeights;
+import org.beehive.gpullama3.model.Model;
+import org.beehive.gpullama3.model.format.ChatFormat;
+import org.beehive.gpullama3.model.llama.LlamaConfiguration;
+import org.beehive.gpullama3.tornadovm.kernels.TransformerBatchPrefillKernels;
+import org.beehive.gpullama3.tornadovm.layers.type.fp16.decode.LlamaFP16LayersBatchDecodeMMA;
+import org.beehive.gpullama3.tornadovm.plan.components.activation.BatchPrefillActivation;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.WorkerGrid2D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.beehive.gpullama3.model.loader.ModelLoader.loadModel;
+
+/**
+ * End-to-end static batched-decode engine for LLaMA FP16: B independent sequences
+ * generate together, one token per step, each attending its OWN KV region.
+ *
+ * <p>Reuses the batched-prefill MMA pipeline (projections as tensor-core GEMMs,
+ * weight read once and applied to all B tokens → compute-bound) but swaps the two
+ * KV-addressing kernels for the per-slot decode variants
+ * ({@link TransformerBatchPrefillKernels#batchedDecodeRopeWithKVCachePacked},
+ * {@link TransformerBatchPrefillKernels#batchedDecodeAttentionFP16Out}) over a
+ * B-sized KV cache.</p>
+ *
+ * <p>ONE step routine serves both phases: prompt tokens are fed with logits
+ * discarded (fills the B KV regions with identical RoPE to decode → no cache
+ * mismatch); then generated tokens are fed back. Greedy sampling with B copies of
+ * the same prompt makes all B streams identical AND equal to the single-stream
+ * greedy reference — a bit-exact end-to-end correctness check — while the aggregate
+ * B×tok/s is the batching win.</p>
+ *
+ * <p>Run (JVM prop {@code -Dllama.prefillBatchSize=B} MUST equal B):</p>
+ * <pre>
+ *   java -Dllama.prefillBatchSize=32 -Dbatch.decode.B=32 -Dbatch.decode.ctx=512 \
+ *        -Dbatch.decode.n=64 ... BatchedDecodeEngine --model llama-3.2-1b-fp16.gguf --prompt "..."
+ * </pre>
+ */
+public class BatchedDecodeEngine {
+
+    static final int RMS_LOCAL = 256;
+
+    public static void main(String[] args) throws Exception {
+        System.setProperty("llama.enableTornadoVM", "true");
+        int B = Integer.getInteger("batch.decode.B", 32);
+        int decodeCtx = Integer.getInteger("batch.decode.ctx", 512);
+        int nDecode = Integer.getInteger("batch.decode.n", 64);
+        boolean cudaGraphs = Boolean.parseBoolean(System.getProperty("batch.decode.cudaGraphs", "true"));
+        if (Integer.getInteger("llama.prefillBatchSize", 1) != B) {
+            throw new IllegalStateException("Set -Dllama.prefillBatchSize=" + B + " to match -Dbatch.decode.B");
+        }
+
+        Options options = Options.parseOptions(args);
+        Model model = loadModel(options);
+        LlamaConfiguration config = (LlamaConfiguration) model.configuration();
+        LlamaTornadoWeights weights = (LlamaTornadoWeights) model.weights();
+        LlamaState state = (LlamaState) model.createNewState();
+
+        int dim = config.dim();
+        int vocab = config.vocabularySize();
+        int kvDim = config.kvDim();
+        int numLayers = config.numberOfLayers();
+        int paddedB = (B + 127) & ~127;
+
+        // ── Prompt tokens ──────────────────────────────────────────────────────
+        ChatFormat cf = model.chatFormat();
+        List<Integer> prompt = new ArrayList<>();
+        if (model.shouldAddBeginOfText()) {
+            prompt.add(cf.getBeginOfText());
+        }
+        prompt.addAll(cf.encodeMessage(new ChatFormat.Message(ChatFormat.Role.USER, options.prompt())));
+        prompt.addAll(cf.encodeHeader(new ChatFormat.Message(ChatFormat.Role.ASSISTANT, "")));
+        int P = prompt.size();
+        var stopTokens = cf.getStopTokens();
+        if (P + nDecode >= decodeCtx) {
+            throw new IllegalStateException("prompt(" + P + ")+n(" + nDecode + ") >= ctx(" + decodeCtx + ")");
+        }
+        System.out.printf("[engine] B=%d ctx=%d promptLen=%d nDecode=%d dim=%d vocab=%d layers=%d cudaGraphs=%b%n",
+                B, decodeCtx, P, nDecode, dim, vocab, numLayers, cudaGraphs);
+
+        // ── Engine-owned buffers ────────────────────────────────────────────────
+        long kvElems = (long) B * numLayers * decodeCtx * kvDim;
+        FloatArray keyCacheBatch = new FloatArray((int) kvElems);
+        FloatArray valueCacheBatch = new FloatArray((int) kvElems);
+        keyCacheBatch.init(0.0f);
+        valueCacheBatch.init(0.0f);
+        IntArray seqPositions = new IntArray(B);
+        FloatArray finalScaleBatch = new FloatArray(B);
+        HalfFloatArray normedFinalFP16 = new HalfFloatArray(paddedB * dim);
+        normedFinalFP16.init(new uk.ac.manchester.tornado.api.types.HalfFloat(0.0f));
+        FloatArray logitsBatch = new FloatArray(paddedB * vocab);
+
+        // ── Graphs: [0] activation, [1..N] decode layers, [N+1] batched logits ──
+        BatchPrefillActivation activation = new BatchPrefillActivation(state, config, B, false);
+        LlamaFP16LayersBatchDecodeMMA layers = new LlamaFP16LayersBatchDecodeMMA(
+                state, weights, config, B, decodeCtx, keyCacheBatch, valueCacheBatch, seqPositions);
+
+        KernelContext logitsCtx = new KernelContext();
+        HalfFloatArray wclsHalf = weights.wclsByteArray.asHalfFloatArray();
+        FloatArray rmsFinal = weights.rms_final_weight_as_floatArray.asFloatArray();
+        String lastLayerId = layers.getLastLayerTaskGraphID();
+        TaskGraph logitsTg = new TaskGraph("batchLogits")
+                .consumeFromDevice(lastLayerId, state.wrapXBatch)
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                        logitsCtx, normedFinalFP16, finalScaleBatch, wclsHalf, rmsFinal)
+                .task("rms_reduce", TransformerBatchPrefillKernels::batchedRmsReduceParallel,
+                        logitsCtx, state.wrapXBatch, finalScaleBatch, dim, config.rmsNormEps(), RMS_LOCAL)
+                .task("rms_apply", TransformerBatchPrefillKernels::batchedFFNRmsApplyFP16,
+                        logitsCtx, normedFinalFP16, state.wrapXBatch, rmsFinal, finalScaleBatch, dim)
+                .task("vocab", TransformerBatchPrefillKernels::gemmMMA,
+                        logitsCtx, normedFinalFP16, wclsHalf, logitsBatch, paddedB, vocab, dim)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, logitsBatch);
+        ImmutableTaskGraph logitsItg = logitsTg.snapshot();
+
+        // ── Grid scheduler ──────────────────────────────────────────────────────
+        GridScheduler gs = new GridScheduler();
+        activation.updateGridScheduler(gs);
+        layers.updateGridScheduler(gs);
+        gs.addWorkerGrid("batchLogits.rms_reduce", genericWorker(B * RMS_LOCAL, RMS_LOCAL));
+        gs.addWorkerGrid("batchLogits.rms_apply", genericWorker(B * dim, 256));
+        gs.addWorkerGrid("batchLogits.vocab", mmaGrid(paddedB, vocab));
+
+        List<ImmutableTaskGraph> all = new ArrayList<>();
+        all.add(activation.getImmutableTaskGraph());
+        all.addAll(layers.getLayerImmutableTaskGraphs());
+        all.add(logitsItg);
+        int nLayers = layers.getLayerImmutableTaskGraphs().size();
+        int logitsIdx = 1 + nLayers;
+
+        MemorySegment embTable = weights.getTokenEmbeddingTable().asHalfFloatArray().getSegment();
+        long dimBytes = (long) dim * Short.BYTES;
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(all.toArray(new ImmutableTaskGraph[0]))) {
+
+            // greedy (bit-exact verification) or per-slot temperature sampling
+            // (divergent independent streams — the real concurrent-request case).
+            float temperature = Float.parseFloat(System.getProperty("batch.decode.temp", "0.0"));
+            boolean sample = temperature > 0.0f;
+            java.util.Random[] rng = new java.util.Random[B];
+            for (int b = 0; b < B; b++) {
+                rng[b] = new java.util.Random(1000 + b);
+            }
+
+            // ── Prefill: all slots run the identical prompt, logits only at last pos.
+            long prefillStart = System.nanoTime();
+            for (int t = 0; t < P; t++) {
+                int tok = prompt.get(t);
+                for (int b = 0; b < B; b++) {
+                    MemorySegment.copy(embTable, (long) tok * dimBytes,
+                            state.embeddingXBatch.getSegment(), (long) b * dimBytes, dimBytes);
+                    seqPositions.set(b, t);
+                }
+                boolean needLogits = (t == P - 1);
+                runStep(plan, gs, nLayers, logitsIdx, needLogits, cudaGraphs);
+            }
+            long prefillNs = System.nanoTime() - prefillStart;
+
+            // First generated token per slot (identical → same greedy argmax).
+            int[][] streams = new int[B][];
+            for (int b = 0; b < B; b++) {
+                streams[b] = new int[nDecode];
+            }
+            int[] cur = new int[B];
+            for (int b = 0; b < B; b++) {
+                int first = sample ? sampleRow(logitsBatch, b, vocab, temperature, rng[b])
+                                   : argmaxRow(logitsBatch, b, vocab);
+                cur[b] = first;
+                streams[b][0] = first;
+            }
+
+            // ── Decode: static batch, greedy. Position advances in lock-step.
+            // First few steps capture the CUDA graphs; exclude them from timing so
+            // the reported latency is steady-state replay, not capture.
+            int warmup = cudaGraphs ? Math.min(4, nDecode - 1) : 0;
+            long decodeNs = 0;
+            int steps = 0;
+            for (int s = 1; s < nDecode; s++) {
+                int pos = P + s - 1;
+                for (int b = 0; b < B; b++) {
+                    MemorySegment.copy(embTable, (long) cur[b] * dimBytes,
+                            state.embeddingXBatch.getSegment(), (long) b * dimBytes, dimBytes);
+                    seqPositions.set(b, pos);
+                }
+                long t0 = System.nanoTime();
+                runStep(plan, gs, nLayers, logitsIdx, true, cudaGraphs);
+                if (s > warmup) {
+                    decodeNs += System.nanoTime() - t0;
+                    steps++;
+                }
+                for (int b = 0; b < B; b++) {
+                    int nt = sample ? sampleRow(logitsBatch, b, vocab, temperature, rng[b])
+                                    : argmaxRow(logitsBatch, b, vocab);
+                    cur[b] = nt;
+                    streams[b][s] = nt;
+                }
+            }
+
+            // ── Verify + report ─────────────────────────────────────────────────
+            boolean allIdentical = true;
+            for (int b = 1; b < B; b++) {
+                for (int s = 0; s < nDecode; s++) {
+                    if (streams[b][s] != streams[0][s]) {
+                        allIdentical = false;
+                    }
+                }
+            }
+            java.util.Set<String> distinct = new java.util.HashSet<>();
+            for (int b = 0; b < B; b++) {
+                distinct.add(java.util.Arrays.toString(streams[b]));
+            }
+            int showSlots = sample ? Math.min(3, B) : 1;
+            for (int b = 0; b < showSlots; b++) {
+                System.out.printf("%n──────────── slot %d output ────────────%n", b);
+                System.out.println(decodeStream(model, streams[b], nDecode, stopTokens));
+                System.out.println("───────────────────────────────────────");
+            }
+            if (sample) {
+                System.out.printf("[verify] mode=sample temp=%.2f: %d/%d streams distinct (independent per-slot KV)%n",
+                        temperature, distinct.size(), B);
+            } else {
+                System.out.printf("[verify] mode=greedy: all %d streams identical (== single-stream greedy ref): %b%n",
+                        B, allIdentical);
+            }
+
+            double decodeSec = decodeNs / 1e9;
+            int genTokens = steps * B;
+            System.out.printf("[perf] prefill %d pos in %.1f ms | decode %d steps × B=%d = %d tokens in %.1f ms%n",
+                    P, prefillNs / 1e6, steps, B, genTokens, decodeNs / 1e6);
+            System.out.printf("[perf] per-step latency %.2f ms | aggregate throughput %.0f tok/s | per-stream %.1f tok/s%n",
+                    decodeNs / 1e6 / steps, genTokens / decodeSec, steps / decodeSec);
+        }
+    }
+
+    private static void runStep(TornadoExecutionPlan plan, GridScheduler gs,
+                                int nLayers, int logitsIdx, boolean needLogits, boolean cudaGraphs) {
+        execGraph(plan, gs, 0, cudaGraphs);
+        for (int l = 0; l < nLayers; l++) {
+            execGraph(plan, gs, 1 + l, cudaGraphs);
+        }
+        if (needLogits) {
+            execGraph(plan, gs, logitsIdx, cudaGraphs);
+        }
+    }
+
+    private static void execGraph(TornadoExecutionPlan plan, GridScheduler gs, int idx, boolean cudaGraphs) {
+        var g = plan.withGraph(idx).withGridScheduler(gs);
+        if (cudaGraphs) {
+            g.withCUDAGraph();
+        }
+        g.execute();
+    }
+
+    private static String decodeStream(Model model, int[] stream, int nDecode, java.util.Set<Integer> stopTokens) {
+        StringBuilder text = new StringBuilder();
+        for (int s = 0; s < nDecode; s++) {
+            int tk = stream[s];
+            if (stopTokens.contains(tk)) {
+                break;
+            }
+            text.append(model.tokenizer().decode(List.of(tk)));
+        }
+        return text.toString();
+    }
+
+    /** Temperature softmax sampling over one logits row. */
+    private static int sampleRow(FloatArray logits, int row, int vocab, float temp, java.util.Random rng) {
+        long base = (long) row * vocab;
+        float max = Float.NEGATIVE_INFINITY;
+        for (int i = 0; i < vocab; i++) {
+            float v = logits.get((int) (base + i));
+            if (v > max) {
+                max = v;
+            }
+        }
+        double sum = 0.0;
+        double[] probs = new double[vocab];
+        for (int i = 0; i < vocab; i++) {
+            double e = Math.exp((logits.get((int) (base + i)) - max) / temp);
+            probs[i] = e;
+            sum += e;
+        }
+        double r = rng.nextDouble() * sum;
+        double acc = 0.0;
+        for (int i = 0; i < vocab; i++) {
+            acc += probs[i];
+            if (acc >= r) {
+                return i;
+            }
+        }
+        return vocab - 1;
+    }
+
+    private static int argmaxRow(FloatArray logits, int row, int vocab) {
+        long base = (long) row * vocab;
+        int best = 0;
+        float bestV = logits.get((int) base);
+        for (int i = 1; i < vocab; i++) {
+            float v = logits.get((int) (base + i));
+            if (v > bestV) {
+                bestV = v;
+                best = i;
+            }
+        }
+        return best;
+    }
+
+    static WorkerGrid genericWorker(int global, int local) {
+        WorkerGrid1D g = new WorkerGrid1D(global);
+        g.setLocalWork(local, 1, 1);
+        return g;
+    }
+
+    static WorkerGrid mmaGrid(int paddedM, int N) {
+        int mBlocks = paddedM / 128;
+        int nBlocks = N / 128;
+        WorkerGrid2D g = new WorkerGrid2D(mBlocks * 256, nBlocks);
+        g.setLocalWork(256, 1, 1);
+        return g;
+    }
+}

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
@@ -56,6 +56,32 @@ import static org.beehive.gpullama3.model.loader.ModelLoader.loadModel;
  *   java -Dllama.prefillBatchSize=32 -Dbatch.decode.B=32 -Dbatch.decode.ctx=512 \
  *        -Dbatch.decode.n=64 ... BatchedDecodeEngine --model llama-3.2-1b-fp16.gguf --prompt "..."
  * </pre>
+ *
+ * <h2>Reproduce (step by step)</h2>
+ * <ol>
+ *   <li>Build a TornadoVM with the CUDA backend + MMA {@code KernelContext} API
+ *       ({@code make BACKEND=cuda}); tested on TornadoVM 5.0.1-jdk21-dev, JDK 21.</li>
+ *   <li>Build this project:
+ *       {@code mvn -Pjdk21 -Dtornadovm.base.version=5.0.1 -Djdk.version.suffix=-jdk21-dev clean package -DskipTests}</li>
+ *   <li>Take {@code llama-tornado --show-command ...}, swap the main class to this
+ *       engine, and prepend the {@code -Dbatch.decode.*} flags below. Keep
+ *       {@code -Dllama.prefillBatchSize} equal to {@code -Dbatch.decode.B}.</li>
+ * </ol>
+ * <p>Qwen3, static batch (all B streams bit-exact vs single-stream greedy):</p>
+ * <pre>
+ *   -Dllama.prefillBatchSize=32 -Dbatch.decode.B=32 -Dbatch.decode.ctx=512 -Dbatch.decode.n=64 \
+ *   BatchedDecodeEngine -m Qwen3-1.7B-f16.gguf -p "What is the capital of France?" --instruct
+ *   # verify: "all 32 streams identical (== single-stream greedy ref): true"
+ * </pre>
+ * <p>Qwen3, continuous multi-request serving (paged KV + prefix cache):</p>
+ * <pre>
+ *   -Dllama.prefillBatchSize=16 -Dbatch.decode.B=16 -Dbatch.decode.ctx=512 -Dbatch.decode.n=64 \
+ *   -Dbatch.decode.continuous=true -Dbatch.decode.paged=true -Dbatch.decode.prefixCache=true \
+ *   -Dbatch.decode.requests=128 \
+ *   BatchedDecodeEngine -m Qwen3-1.7B-f16.gguf -p "What is the capital of France?" --instruct
+ *   # verify: "128 requests completed, all mutually prefix-consistent (greedy): true"
+ * </pre>
+ * <p>Each run prints {@code [verify] ...: true} (correctness) and {@code [perf] ...} (throughput).</p>
  */
 public class BatchedDecodeEngine {
 

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedDecodeEngine.java
@@ -174,6 +174,13 @@ public class BatchedDecodeEngine {
 
         try (TornadoExecutionPlan plan = new TornadoExecutionPlan(all.toArray(new ImmutableTaskGraph[0]))) {
 
+            if (Boolean.parseBoolean(System.getProperty("batch.decode.continuous", "false"))) {
+                runContinuous(plan, gs, nLayers, logitsIdx, cudaGraphs, model, B, dim, vocab, nDecode,
+                        prompt, stopTokens, embTable, dimBytes, state.embeddingXBatch.getSegment(),
+                        seqPositions, logitsBatch);
+                return;
+            }
+
             // greedy (bit-exact verification) or per-slot temperature sampling
             // (divergent independent streams — the real concurrent-request case).
             float temperature = Float.parseFloat(System.getProperty("batch.decode.temp", "0.0"));
@@ -271,6 +278,172 @@ public class BatchedDecodeEngine {
             System.out.printf("[perf] per-step latency %.2f ms | aggregate throughput %.0f tok/s | per-stream %.1f tok/s%n",
                     decodeNs / 1e6 / steps, genTokens / decodeSec, steps / decodeSec);
         }
+    }
+
+    /**
+     * Continuous (iteration-level) batching: B slots, each independently either
+     * PREFILLING its prompt (token-by-token, logits ignored) or DECODING. A slot
+     * that hits a stop token / its max-gen is evicted and immediately refilled from
+     * the pending queue — no waiting for the slowest slot in a wave. Because the
+     * per-step forward already feeds one token per slot at its own {@code seqPositions[b]}
+     * with its own KV region, prefill and decode are the same op; new requests join
+     * a partly-decoded batch mid-flight (Orca-style scheduling).
+     *
+     * Workload: R requests of the same prompt (greedy → deterministic) with random
+     * max-gen lengths, so slots finish at different steps and exercise evict/admit.
+     * Correctness = all completed outputs are mutually prefix-consistent (the shorter
+     * is a prefix of the longer), proving each slot decoded correctly regardless of
+     * when it joined.
+     */
+    private static void runContinuous(TornadoExecutionPlan plan, GridScheduler gs, int nLayers, int logitsIdx,
+                                      boolean cudaGraphs, Model model, int B, int dim, int vocab, int nDecode,
+                                      List<Integer> prompt, java.util.Set<Integer> stopTokens,
+                                      MemorySegment embTable, long dimBytes, MemorySegment embBatchSeg,
+                                      IntArray seqPositions, FloatArray logitsBatch) {
+        int R = Integer.getInteger("batch.decode.requests", 4 * B);
+        int minN = Integer.getInteger("batch.decode.minN", Math.max(1, nDecode / 2));
+        // refill=true → continuous (admit into a freed slot immediately);
+        // refill=false → static-wave baseline (idle until the whole wave finishes, then reload).
+        boolean refill = Boolean.parseBoolean(System.getProperty("batch.decode.refill", "true"));
+        int promptLen = prompt.size();
+        java.util.Random wl = new java.util.Random(7);
+        java.util.ArrayDeque<Integer> queue = new java.util.ArrayDeque<>();
+        for (int i = 0; i < R; i++) {
+            queue.add(minN + wl.nextInt(Math.max(1, nDecode - minN + 1)));
+        }
+        System.out.printf("[continuous] requests=%d maxGen∈[%d,%d] B=%d%n", R, minN, nDecode, B);
+
+        int[] promptPos = new int[B], pos = new int[B], curTok = new int[B], maxGen = new int[B];
+        boolean[] decoding = new boolean[B], active = new boolean[B];
+        List<List<Integer>> gen = new ArrayList<>();
+        for (int b = 0; b < B; b++) {
+            gen.add(new ArrayList<>());
+        }
+        List<int[]> completed = new ArrayList<>();
+        for (int b = 0; b < B; b++) {
+            if (!queue.isEmpty()) {
+                maxGen[b] = queue.poll();
+                active[b] = true;
+            }
+        }
+
+        int warm = cudaGraphs ? 4 : 0;
+        long steps = 0, genTokens = 0, busySlotSteps = 0, timedNs = 0, timedGen = 0, timedBusy = 0, timedSteps = 0;
+        long tTimed = 0;
+        while (true) {
+            boolean anyActive = false;
+            for (int b = 0; b < B; b++) {
+                if (active[b]) { anyActive = true; break; }
+            }
+            if (!anyActive) {
+                if (queue.isEmpty()) {
+                    break;
+                }
+                // static-wave baseline: whole wave drained → load the next wave.
+                for (int b = 0; b < B; b++) {
+                    if (!queue.isEmpty()) {
+                        maxGen[b] = queue.poll();
+                        promptPos[b] = 0;
+                        pos[b] = 0;
+                        decoding[b] = false;
+                        active[b] = true;
+                    }
+                }
+            }
+            for (int b = 0; b < B; b++) {
+                int tok = active[b] ? (decoding[b] ? curTok[b] : prompt.get(promptPos[b])) : prompt.get(0);
+                MemorySegment.copy(embTable, (long) tok * dimBytes, embBatchSeg, (long) b * dimBytes, dimBytes);
+                seqPositions.set(b, active[b] ? pos[b] : 0);
+            }
+            long t0 = System.nanoTime();
+            runStep(plan, gs, nLayers, logitsIdx, true, cudaGraphs);
+            long dt = System.nanoTime() - t0;
+            steps++;
+
+            long stepGen = 0, stepBusy = 0;
+            for (int b = 0; b < B; b++) {
+                if (!active[b]) {
+                    continue;
+                }
+                stepBusy++;
+                pos[b]++;
+                boolean produced = false;
+                int nt = 0;
+                if (!decoding[b]) {
+                    if (promptPos[b] == promptLen - 1) {          // just fed the last prompt token
+                        nt = argmaxRow(logitsBatch, b, vocab);
+                        decoding[b] = true;
+                        produced = true;
+                    } else {
+                        promptPos[b]++;
+                    }
+                } else {
+                    nt = argmaxRow(logitsBatch, b, vocab);
+                    produced = true;
+                }
+                if (produced) {
+                    gen.get(b).add(nt);
+                    curTok[b] = nt;
+                    genTokens++;
+                    stepGen++;
+                    boolean stop = stopTokens.contains(nt) || gen.get(b).size() >= maxGen[b];
+                    if (stop) {
+                        completed.add(gen.get(b).stream().mapToInt(Integer::intValue).toArray());
+                        gen.get(b).clear();
+                        if (refill && !queue.isEmpty()) {          // continuous: admit next request now
+                            maxGen[b] = queue.poll();
+                            promptPos[b] = 0;
+                            pos[b] = 0;
+                            decoding[b] = false;
+                        } else {                                    // static-wave: idle until wave ends
+                            active[b] = false;
+                        }
+                    }
+                }
+            }
+            busySlotSteps += stepBusy;
+            if (steps > warm) {
+                if (timedSteps == 0) {
+                    tTimed = System.nanoTime();
+                }
+                timedNs += dt;
+                timedGen += stepGen;
+                timedBusy += stepBusy;
+                timedSteps++;
+            }
+        }
+        long wallNs = System.nanoTime() - tTimed;
+
+        // ── Verify: mutually prefix-consistent (greedy, same prompt) ─────────────
+        completed.sort(java.util.Comparator.comparingInt(a -> a.length));
+        boolean consistent = true;
+        int[] longest = completed.isEmpty() ? new int[0] : completed.get(completed.size() - 1);
+        for (int[] r : completed) {
+            for (int i = 0; i < r.length; i++) {
+                if (r[i] != longest[i]) {
+                    consistent = false;
+                }
+            }
+        }
+        StringBuilder text = new StringBuilder();
+        for (int tk : longest) {
+            if (stopTokens.contains(tk)) {
+                break;
+            }
+            text.append(model.tokenizer().decode(List.of(tk)));
+        }
+        System.out.println("\n──────────── longest completed request ────────────");
+        System.out.println(text);
+        System.out.println("───────────────────────────────────────────────────");
+        System.out.printf("[verify] %d requests completed, all mutually prefix-consistent (greedy): %b%n",
+                completed.size(), consistent);
+
+        double sec = wallNs / 1e9;
+        double util = timedSteps > 0 ? (double) timedBusy / (timedSteps * B) : 0.0;
+        System.out.printf("[perf] continuous: %d steps, %d gen tokens over %.2f s%n", steps, genTokens, sec);
+        System.out.printf("[perf] generated %.0f tok/s | %.1f requests/s | slot utilization %.1f%% | per-step %.2f ms%n",
+                timedGen / sec, completed.size() / (wallNs / 1e9), util * 100.0,
+                timedSteps > 0 ? timedNs / 1e6 / timedSteps : 0.0);
     }
 
     private static void runStep(TornadoExecutionPlan plan, GridScheduler gs,

--- a/src/main/java/org/beehive/gpullama3/bench/BatchedProjectionBench.java
+++ b/src/main/java/org/beehive/gpullama3/bench/BatchedProjectionBench.java
@@ -1,0 +1,153 @@
+package org.beehive.gpullama3.bench;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+
+import java.util.Random;
+
+/**
+ * Shows the projection batching win directly: a projection C[B,N] = X[B,K] · Wᵀ
+ * where W is [N,K]. In batched form each weight row W[n] is loaded into shared
+ * memory once per workgroup and reused across all B tokens (arithmetic intensity
+ * ~B → compute-bound); the single-token path re-reads W[n] for every token
+ * (memory-bound). This is why batching turns decode matvecs into a compute-bound
+ * win — the opposite regime from attention (memory-bound, ~2×).
+ *
+ * Synthetic FP32, Llama-1B-ish projection shape (K=N=2048). No model load.
+ * Run: ... BatchedProjectionBench [B] [K] [N]
+ */
+public class BatchedProjectionBench {
+
+    static final int LOCAL = 128;
+
+    /** One workgroup per output column n: load W[n] to shared, apply to all B tokens. */
+    public static void batchedProjection(KernelContext ctx, FloatArray x, FloatArray w, FloatArray c, int B, int K, int N) {
+        int n = ctx.groupIdx;         // output column
+        int tid = ctx.localIdx;
+        int localSz = ctx.localGroupSizeX;
+        float[] wRow = ctx.allocateFloatLocalArray(2048); // K <= 2048
+        for (int i = tid; i < K; i += localSz) {
+            wRow[i] = w.get(n * K + i);
+        }
+        ctx.localBarrier();
+        for (int b = tid; b < B; b += localSz) {
+            float acc = 0.0f;
+            int xoff = b * K;
+            for (int i = 0; i < K; i++) {
+                acc += wRow[i] * x.get(xoff + i);
+            }
+            c.set(b * N + n, acc);
+        }
+    }
+
+    /** Single-token matvec: one workgroup per output column, W[n] re-read from global. */
+    public static void singleProjection(KernelContext ctx, FloatArray x, FloatArray w, FloatArray c, int K, int N) {
+        int n = ctx.groupIdx;
+        int tid = ctx.localIdx;
+        int localSz = ctx.localGroupSizeX;
+        float[] partial = ctx.allocateFloatLocalArray(LOCAL);
+        float acc = 0.0f;
+        for (int i = tid; i < K; i += localSz) {
+            acc += w.get(n * K + i) * x.get(i);
+        }
+        partial[tid] = acc;
+        ctx.localBarrier();
+        for (int s = localSz / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                partial[tid] += partial[tid + s];
+            }
+            ctx.localBarrier();
+        }
+        if (tid == 0) {
+            c.set(n, partial[0]);
+        }
+    }
+
+    public static void main(String[] args) throws TornadoExecutionPlanException {
+        int B = args.length > 0 ? Integer.parseInt(args[0]) : 32;
+        int K = args.length > 1 ? Integer.parseInt(args[1]) : 2048;
+        int N = args.length > 2 ? Integer.parseInt(args[2]) : 2048;
+        int iters = 100;
+        Random rnd = new Random(1);
+
+        FloatArray w = new FloatArray(N * K);
+        for (int i = 0; i < N * K; i++) {
+            w.set(i, rnd.nextFloat() - 0.5f);
+        }
+        FloatArray xB = new FloatArray(B * K);
+        for (int i = 0; i < B * K; i++) {
+            xB.set(i, rnd.nextFloat() - 0.5f);
+        }
+        FloatArray cB = new FloatArray(B * N);
+
+        KernelContext ctx = new KernelContext();
+        WorkerGrid1D wg = new WorkerGrid1D(N * LOCAL);
+        wg.setLocalWork(LOCAL, 1, 1);
+        GridScheduler gs = new GridScheduler("p.proj", wg);
+        TaskGraph tg = new TaskGraph("p") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, xB, w) //
+                .task("proj", BatchedProjectionBench::batchedProjection, ctx, xB, w, cB, B, K, N) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, cB);
+
+        double batchedMs;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.withGridScheduler(gs);
+            for (int i = 0; i < 10; i++) {
+                plan.execute();
+            }
+            // correctness (row 0..N, token 0)
+            double maxRel = 0.0;
+            for (int n = 0; n < Math.min(N, 256); n++) {
+                float ref = 0.0f;
+                for (int i = 0; i < K; i++) {
+                    ref += w.get(n * K + i) * xB.get(i);
+                }
+                float got = cB.get(n); // token 0 output
+                maxRel = Math.max(maxRel, Math.abs(ref - got) / Math.max(1e-2, Math.abs(ref)));
+            }
+            long s = System.nanoTime();
+            for (int i = 0; i < iters; i++) {
+                plan.execute();
+            }
+            batchedMs = (System.nanoTime() - s) / 1e6 / iters;
+            System.out.printf("Batched projection K=%d N=%d B=%d  correctness maxRel(tok0)=%.4f%n", K, N, B, maxRel);
+        }
+
+        // single-token matvec
+        FloatArray x1 = new FloatArray(K);
+        for (int i = 0; i < K; i++) {
+            x1.set(i, rnd.nextFloat() - 0.5f);
+        }
+        FloatArray c1 = new FloatArray(N);
+        KernelContext ctx1 = new KernelContext();
+        WorkerGrid1D wg1 = new WorkerGrid1D(N * LOCAL);
+        wg1.setLocalWork(LOCAL, 1, 1);
+        GridScheduler gs1 = new GridScheduler("s.proj", wg1);
+        TaskGraph tg1 = new TaskGraph("s") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, x1, w) //
+                .task("proj", BatchedProjectionBench::singleProjection, ctx1, x1, w, c1, K, N) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c1);
+        double singleMs;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg1.snapshot())) {
+            plan.withGridScheduler(gs1);
+            for (int i = 0; i < 10; i++) {
+                plan.execute();
+            }
+            long s = System.nanoTime();
+            for (int i = 0; i < iters; i++) {
+                plan.execute();
+            }
+            singleMs = (System.nanoTime() - s) / 1e6 / iters;
+        }
+        System.out.printf("  batched %d tokens: %.4f ms  |  1 token: %.4f ms  |  B*single=%.4f ms%n",
+                B, batchedMs, singleMs, singleMs * B);
+        System.out.printf("  projection speedup (B matvecs -> 1 batched GEMM): %.2fx  (%.0f vs %.0f tok/s)%n",
+                (singleMs * B) / batchedMs, B / (batchedMs / 1000.0), 1.0 / (singleMs / 1000.0));
+    }
+}

--- a/src/main/java/org/beehive/gpullama3/tornadovm/kernels/Qwen3Kernels.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/kernels/Qwen3Kernels.java
@@ -1513,5 +1513,66 @@ public class Qwen3Kernels {
         }
     }
 
+    /**
+     * Per-slot Qwen3 split-half RoPE + KV-cache write (batched DECODE).
+     *
+     * <p>Fork of {@link #batchedRopeWithKVCacheQwen3Packed}: each slot rotates at its
+     * own position {@code seqPositions[batchIdx]} and writes K/V into its own KV
+     * region ({@code batchIdx} stride = {@code numLayers*contextLength*kvDim}).</p>
+     */
+    public static void batchedDecodeRopeWithKVCacheQwen3Packed(
+            KernelContext context,
+            IntArray seqPositions,
+            FloatArray qkvBatch,
+            FloatArray wrapKeyCache,
+            FloatArray wrapValueCache,
+            int kvDim,
+            int nEmbdHead,
+            int layerIndex,
+            int numLayers,
+            int contextLength,
+            int qDim) {
+
+        int globalIdx = context.globalIdx;
+        int halfQDim = qDim / 2;
+        int batchIdx = globalIdx / halfQDim;
+        int pairIdx = globalIdx % halfQDim;
+        int qkvStride = qDim + 2 * kvDim;
+
+        int pos = seqPositions.get(batchIdx);
+
+        int halfEmbdHead = nEmbdHead / 2;
+        int ic      = pairIdx % halfEmbdHead;
+        int headIdx = pairIdx / halfEmbdHead;
+
+        float freq = 1.0f / TornadoMath.pow(1000000.0f, 2.0f * ic / (float) nEmbdHead);
+        float val  = pos * freq;
+        float fcr  = TornadoMath.cos(val);
+        float fci  = TornadoMath.sin(val);
+
+        int qHeadBase = batchIdx * qkvStride + headIdx * nEmbdHead;
+        float v0q = qkvBatch.get(qHeadBase + ic);
+        float v1q = qkvBatch.get(qHeadBase + ic + halfEmbdHead);
+        qkvBatch.set(qHeadBase + ic,                v0q * fcr - v1q * fci);
+        qkvBatch.set(qHeadBase + ic + halfEmbdHead, v0q * fci + v1q * fcr);
+
+        if (pairIdx < kvDim / 2) {
+            int kHeadIdx  = pairIdx / halfEmbdHead;
+            int kHeadBase = batchIdx * qkvStride + qDim + kHeadIdx * nEmbdHead;
+            int vHeadBase = batchIdx * qkvStride + qDim + kvDim + kHeadIdx * nEmbdHead;
+            float v0k = qkvBatch.get(kHeadBase + ic);
+            float v1k = qkvBatch.get(kHeadBase + ic + halfEmbdHead);
+            float rotK0 = v0k * fcr - v1k * fci;
+            float rotK1 = v0k * fci + v1k * fcr;
+
+            int slotBase = batchIdx * (numLayers * contextLength * kvDim);
+            int cacheOff = slotBase + layerIndex * contextLength * kvDim + pos * kvDim + kHeadIdx * nEmbdHead;
+            wrapKeyCache.set(cacheOff + ic,                rotK0);
+            wrapKeyCache.set(cacheOff + ic + halfEmbdHead, rotK1);
+            wrapValueCache.set(cacheOff + ic,                qkvBatch.get(vHeadBase + ic));
+            wrapValueCache.set(cacheOff + ic + halfEmbdHead, qkvBatch.get(vHeadBase + ic + halfEmbdHead));
+        }
+    }
+
 }
 // @formatter:on

--- a/src/main/java/org/beehive/gpullama3/tornadovm/kernels/Qwen3Kernels.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/kernels/Qwen3Kernels.java
@@ -1574,5 +1574,67 @@ public class Qwen3Kernels {
         }
     }
 
+    /**
+     * Paged Qwen3 split-half RoPE + KV write (block-table indirection). {@code blockCfg}
+     * packs {@code blockSize | (maxBlocksPerSlot << 16)}. Paired flash attention is the
+     * shared {@code batchedDecodePagedAttentionFP16Out} (qDim == nHeads*nEmbdHead).
+     */
+    public static void batchedDecodePagedRopeWithKVCacheQwen3Packed(
+            KernelContext context,
+            IntArray seqPositions,
+            IntArray blockTable,
+            FloatArray qkvBatch,
+            FloatArray keyPool,
+            FloatArray valuePool,
+            int kvDim,
+            int nEmbdHead,
+            int layerIndex,
+            int numLayers,
+            int blockCfg,
+            int qDim) {
+        int blockSize = blockCfg & 0xFFFF;
+        int maxBlocksPerSlot = blockCfg >>> 16;
+        int globalIdx = context.globalIdx;
+        int halfQDim = qDim / 2;
+        int batchIdx = globalIdx / halfQDim;
+        int pairIdx = globalIdx % halfQDim;
+        int qkvStride = qDim + 2 * kvDim;
+
+        int pos = seqPositions.get(batchIdx);
+
+        int halfEmbdHead = nEmbdHead / 2;
+        int ic      = pairIdx % halfEmbdHead;
+        int headIdx = pairIdx / halfEmbdHead;
+
+        float freq = 1.0f / TornadoMath.pow(1000000.0f, 2.0f * ic / (float) nEmbdHead);
+        float val  = pos * freq;
+        float fcr  = TornadoMath.cos(val);
+        float fci  = TornadoMath.sin(val);
+
+        int qHeadBase = batchIdx * qkvStride + headIdx * nEmbdHead;
+        float v0q = qkvBatch.get(qHeadBase + ic);
+        float v1q = qkvBatch.get(qHeadBase + ic + halfEmbdHead);
+        qkvBatch.set(qHeadBase + ic,                v0q * fcr - v1q * fci);
+        qkvBatch.set(qHeadBase + ic + halfEmbdHead, v0q * fci + v1q * fcr);
+
+        if (pairIdx < kvDim / 2) {
+            int kHeadIdx  = pairIdx / halfEmbdHead;
+            int kHeadBase = batchIdx * qkvStride + qDim + kHeadIdx * nEmbdHead;
+            int vHeadBase = batchIdx * qkvStride + qDim + kvDim + kHeadIdx * nEmbdHead;
+            float v0k = qkvBatch.get(kHeadBase + ic);
+            float v1k = qkvBatch.get(kHeadBase + ic + halfEmbdHead);
+            float rotK0 = v0k * fcr - v1k * fci;
+            float rotK1 = v0k * fci + v1k * fcr;
+
+            int physBlock = blockTable.get(batchIdx * maxBlocksPerSlot + pos / blockSize);
+            int cacheOff = physBlock * (numLayers * blockSize * kvDim)
+                    + layerIndex * (blockSize * kvDim) + (pos % blockSize) * kvDim + kHeadIdx * nEmbdHead;
+            keyPool.set(cacheOff + ic,                rotK0);
+            keyPool.set(cacheOff + ic + halfEmbdHead, rotK1);
+            valuePool.set(cacheOff + ic,                qkvBatch.get(vHeadBase + ic));
+            valuePool.set(cacheOff + ic + halfEmbdHead, qkvBatch.get(vHeadBase + ic + halfEmbdHead));
+        }
+    }
+
 }
 // @formatter:on

--- a/src/main/java/org/beehive/gpullama3/tornadovm/kernels/TransformerBatchPrefillKernels.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/kernels/TransformerBatchPrefillKernels.java
@@ -1983,6 +1983,52 @@ public final class TransformerBatchPrefillKernels {
         }
     }
 
+    // ── On-device greedy sampling (argmax) ──────────────────────────────────
+
+    /**
+     * Per-row argmax over the batched logits: one workgroup per row reduces over the
+     * whole vocab and writes the winning token id to {@code outTokens[b]}. Keeps the
+     * full logits tensor on the GPU — only B integers cross to the host, instead of
+     * the paddedB×vocab (~65–78 MB) D2H copy + a CPU scan every step.
+     *
+     * Worker: B workgroups × localSize threads (localSize a power of two, e.g. 256).
+     */
+    public static void batchedArgmaxLogits(KernelContext context,
+                                           FloatArray logits, IntArray outTokens, int vocab) {
+        int b = context.groupIdx;
+        int tid = context.localIdx;
+        int localSz = context.localGroupSizeX;
+        float[] vals = context.allocateFloatLocalArray(256);
+        int[] idxs = context.allocateIntLocalArray(256);
+
+        int base = b * vocab;
+        float best = Float.NEGATIVE_INFINITY;
+        int bestIdx = 0;
+        for (int i = tid; i < vocab; i += localSz) {
+            float v = logits.get(base + i);
+            if (v > best) {
+                best = v;
+                bestIdx = i;
+            }
+        }
+        vals[tid] = best;
+        idxs[tid] = bestIdx;
+        context.localBarrier();
+
+        for (int s = localSz / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                if (vals[tid + s] > vals[tid]) {
+                    vals[tid] = vals[tid + s];
+                    idxs[tid] = idxs[tid + s];
+                }
+            }
+            context.localBarrier();
+        }
+        if (tid == 0) {
+            outTokens.set(b, idxs[0]);
+        }
+    }
+
     // ── SwiGLU over the packed gate/up buffer, emitting FP16 ─────────────────
 
     /**

--- a/src/main/java/org/beehive/gpullama3/tornadovm/kernels/TransformerBatchPrefillKernels.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/kernels/TransformerBatchPrefillKernels.java
@@ -1805,6 +1805,184 @@ public final class TransformerBatchPrefillKernels {
         }
     }
 
+    // ── Paged KV variants (block-table indirection) ─────────────────────────
+    //
+    // KV lives in a global pool of fixed-size blocks. A block holds `blockSize`
+    // consecutive positions of ONE sequence across ALL layers:
+    //   pool[ physBlock*(numLayers*blockSize*kvDim) + layer*(blockSize*kvDim)
+    //         + (pos % blockSize)*kvDim + c ]
+    // The per-slot block table maps a logical block to a physical one:
+    //   physBlock = blockTable[batchIdx*maxBlocksPerSlot + pos/blockSize]
+    // This removes the fixed per-slot context reservation of the contiguous cache:
+    // slots draw blocks from a shared pool only for the tokens they actually hold,
+    // so the pool can be far smaller than B*ctx (and blocks can be shared for
+    // prefix caching).
+
+    /**
+     * Paged per-slot RoPE + KV write (Llama adjacent-pair). {@code blockCfg} packs
+     * {@code blockSize | (maxBlocksPerSlot << 16)} to stay within the task arg limit.
+     */
+    public static void batchedDecodePagedRopeWithKVCachePacked(KernelContext context,
+                                                              IntArray seqPositions,
+                                                              IntArray blockTable,
+                                                              FloatArray qkvBatch,
+                                                              FloatArray keyPool,
+                                                              FloatArray valuePool,
+                                                              int kvDim, int headSize,
+                                                              int layerIndex, int numLayers,
+                                                              int blockCfg, int dim) {
+        int blockSize = blockCfg & 0xFFFF;
+        int maxBlocksPerSlot = blockCfg >>> 16;
+        int globalIdx = context.globalIdx;
+        int halfDim = dim / 2;
+        int batchIdx = globalIdx / halfDim;
+        int pairIdx = globalIdx % halfDim;
+        int i = pairIdx * 2;
+        int qkvStride = dim + 2 * kvDim;
+
+        int pos = seqPositions.get(batchIdx);
+        int qOffset = batchIdx * qkvStride;
+        int kOffset = batchIdx * qkvStride + dim;
+        int vOffset = batchIdx * qkvStride + dim + kvDim;
+
+        if (i + 1 < dim) {
+            int head_dim = i % headSize;
+            float freq = 1.0f / TornadoMath.pow(50000.0f, head_dim / (float) headSize);
+            float val = pos * freq;
+            float fcr = TornadoMath.cos(val);
+            float fci = TornadoMath.sin(val);
+
+            float v0q = qkvBatch.get(qOffset + i);
+            float v1q = qkvBatch.get(qOffset + i + 1);
+            qkvBatch.set(qOffset + i, v0q * fcr - v1q * fci);
+            qkvBatch.set(qOffset + i + 1, v0q * fci + v1q * fcr);
+
+            if (i + 1 < kvDim) {
+                float v0k = qkvBatch.get(kOffset + i);
+                float v1k = qkvBatch.get(kOffset + i + 1);
+                float rotK0 = v0k * fcr - v1k * fci;
+                float rotK1 = v0k * fci + v1k * fcr;
+
+                int physBlock = blockTable.get(batchIdx * maxBlocksPerSlot + pos / blockSize);
+                int slotInBlock = pos % blockSize;
+                int cacheOff = physBlock * (numLayers * blockSize * kvDim)
+                        + layerIndex * (blockSize * kvDim) + slotInBlock * kvDim;
+                keyPool.set(cacheOff + i, rotK0);
+                keyPool.set(cacheOff + i + 1, rotK1);
+                valuePool.set(cacheOff + i, qkvBatch.get(vOffset + i));
+                valuePool.set(cacheOff + i + 1, qkvBatch.get(vOffset + i + 1));
+            }
+        }
+    }
+
+    /**
+     * Paged per-slot flash attention, FP16 output (Llama; {@code dim = nHeads*headSize}).
+     * {@code blockCfg} packs {@code blockSize | (maxBlocksPerSlot << 16)}.
+     */
+    public static void batchedDecodePagedAttentionFP16Out(KernelContext context,
+                                                          IntArray seqPositions,
+                                                          IntArray blockTable,
+                                                          FloatArray qkvBatch,
+                                                          FloatArray keyPool,
+                                                          FloatArray valuePool,
+                                                          HalfFloatArray attnOutFP16,
+                                                          int nHeads, int headSize,
+                                                          int kvDim, int kvMul,
+                                                          int layerIndex, int numLayers,
+                                                          int blockCfg) {
+        int blockSize = blockCfg & 0xFFFF;
+        int maxBlocksPerSlot = blockCfg >>> 16;
+        int dim = nHeads * headSize;
+        int tid = context.localIdx;
+        int groupId = context.groupIdx;
+        int localSz = context.localGroupSizeX;
+
+        int batchIdx = groupId / nHeads;
+        int h = groupId % nHeads;
+        int pos = seqPositions.get(batchIdx);
+        int layerOff = layerIndex * (blockSize * kvDim);
+        int kvHeadIdx = h / kvMul;
+        int BLOCK_C = 16;
+        int qkvStride = dim + 2 * kvDim;
+        int blockStride = numLayers * blockSize * kvDim;
+
+        float[] qShared = context.allocateFloatLocalArray(headSize);
+        float[] kTile = context.allocateFloatLocalArray(BLOCK_C * headSize);
+        float[] vTile = context.allocateFloatLocalArray(BLOCK_C * headSize);
+        float[] sTile = context.allocateFloatLocalArray(BLOCK_C);
+
+        int qOffset = batchIdx * qkvStride + h * headSize;
+        for (int i = tid; i < headSize; i += localSz) {
+            qShared[i] = qkvBatch.get(qOffset + i);
+        }
+        context.localBarrier();
+
+        float maxScore = Float.NEGATIVE_INFINITY;
+        float sumExp = 0.0f;
+        float acc0 = 0.0f;
+        float acc1 = 0.0f;
+        int d1 = tid + localSz;
+
+        for (int tileC = 0; tileC <= pos; tileC += BLOCK_C) {
+            int tileEnd = Math.min(tileC + BLOCK_C - 1, pos);
+            int tileLen = tileEnd - tileC + 1;
+
+            for (int idx = tid; idx < tileLen * headSize; idx += localSz) {
+                int tInTile = idx / headSize;
+                int d = idx % headSize;
+                int t = tileC + tInTile;
+                int physBlock = blockTable.get(batchIdx * maxBlocksPerSlot + t / blockSize);
+                int kvOff = physBlock * blockStride + layerOff + (t % blockSize) * kvDim + kvHeadIdx * headSize + d;
+                kTile[tInTile * headSize + d] = keyPool.get(kvOff);
+                vTile[tInTile * headSize + d] = valuePool.get(kvOff);
+            }
+            context.localBarrier();
+
+            for (int t = tileC + tid; t <= tileEnd; t += localSz) {
+                int tInTile = t - tileC;
+                float score = 0.0f;
+                for (int d = 0; d < headSize; d++) {
+                    score += qShared[d] * kTile[tInTile * headSize + d];
+                }
+                sTile[tInTile] = score / TornadoMath.sqrt(headSize);
+            }
+            context.localBarrier();
+
+            float tileMax = Float.NEGATIVE_INFINITY;
+            for (int t = 0; t < tileLen; t++) {
+                if (sTile[t] > tileMax) {
+                    tileMax = sTile[t];
+                }
+            }
+
+            float newMax = Math.max(maxScore, tileMax);
+            if (maxScore != Float.NEGATIVE_INFINITY && newMax != maxScore) {
+                float corr = TornadoMath.exp(maxScore - newMax);
+                sumExp *= corr;
+                acc0 *= corr;
+                acc1 *= corr;
+            }
+            maxScore = newMax;
+
+            for (int t = 0; t < tileLen; t++) {
+                float p = TornadoMath.exp(sTile[t] - maxScore);
+                sumExp += p;
+                acc0 += p * vTile[t * headSize + tid];
+                if (d1 < headSize) {
+                    acc1 += p * vTile[t * headSize + d1];
+                }
+            }
+            context.localBarrier();
+        }
+
+        float norm = (sumExp > 0.0f) ? (1.0f / sumExp) : 0.0f;
+        int outOffset = batchIdx * dim + h * headSize;
+        attnOutFP16.set(outOffset + tid, new HalfFloat(acc0 * norm));
+        if (d1 < headSize) {
+            attnOutFP16.set(outOffset + d1, new HalfFloat(acc1 * norm));
+        }
+    }
+
     // ── SwiGLU over the packed gate/up buffer, emitting FP16 ─────────────────
 
     /**

--- a/src/main/java/org/beehive/gpullama3/tornadovm/kernels/TransformerBatchPrefillKernels.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/kernels/TransformerBatchPrefillKernels.java
@@ -336,6 +336,121 @@ public final class TransformerBatchPrefillKernels {
         }
     }
 
+    /**
+     * Batched DECODE flash attention: B independent sequences, one query token
+     * each. Identical online-softmax math to {@link #batchedFlashAttention}, but
+     * each batch slot has its OWN KV cache region and its OWN position, so slot
+     * {@code b} attends positions {@code 0..seqPositions[b]} of its own cache —
+     * the shape produced by batching B concurrent decode requests.
+     *
+     * <p>KV cache layout: one contiguous region of {@code numLayers *
+     * contextLength * kvDim} per slot, so the base for slot b, layer L is
+     * {@code b*numLayers*contextLength*kvDim + L*contextLength*kvDim}.</p>
+     *
+     * <p>One workgroup per (batchIdx, head): {@code groupId = batchIdx*nHeads + h}.</p>
+     */
+    public static void batchedDecodeAttention(KernelContext context,
+                                              IntArray seqPositions,
+                                              FloatArray wrapQBatch,
+                                              FloatArray wrapKeyCache,
+                                              FloatArray wrapValueCache,
+                                              FloatArray wrapXbBatch,
+                                              int nHeads, int headSize,
+                                              int kvDim, int kvMul,
+                                              int layerIndex, int numLayers, int contextLength, int dim) {
+        int tid = context.localIdx;
+        int groupId = context.groupIdx;
+        int localSz = context.localGroupSizeX;
+
+        int batchIdx = groupId / nHeads;
+        int h = groupId % nHeads;
+        int pos = seqPositions.get(batchIdx);                                 // per-slot position
+        int loff = batchIdx * (numLayers * contextLength * kvDim) + layerIndex * contextLength * kvDim; // per-slot KV base
+        int kvHeadIdx = h / kvMul;
+        int BLOCK_C = 16;
+
+        float[] qShared = context.allocateFloatLocalArray(headSize);
+        float[] kTile = context.allocateFloatLocalArray(BLOCK_C * headSize);
+        float[] vTile = context.allocateFloatLocalArray(BLOCK_C * headSize);
+        float[] sTile = context.allocateFloatLocalArray(BLOCK_C);
+        float[] maxHolder = context.allocateFloatLocalArray(1);
+
+        int qOffset = batchIdx * dim + h * headSize;
+        for (int i = tid; i < headSize; i += localSz) {
+            qShared[i] = wrapQBatch.get(qOffset + i);
+        }
+        context.localBarrier();
+
+        float maxScore = Float.NEGATIVE_INFINITY;
+        float sumExp = 0.0f;
+        float[] output = new float[headSize];
+        for (int i = 0; i < headSize; i++) {
+            output[i] = 0.0f;
+        }
+
+        for (int tileC = 0; tileC <= pos; tileC += BLOCK_C) {
+            int tileEnd = Math.min(tileC + BLOCK_C - 1, pos);
+
+            for (int t = tileC + tid; t <= tileEnd; t += localSz) {
+                int tInTile = t - tileC;
+                int tileMOff = tInTile * headSize;
+                for (int d = 0; d < headSize; d++) {
+                    int kvOff = loff + t * kvDim + kvHeadIdx * headSize + d;
+                    kTile[tileMOff + d] = wrapKeyCache.get(kvOff);
+                    vTile[tileMOff + d] = wrapValueCache.get(kvOff);
+                }
+            }
+            context.localBarrier();
+
+            for (int t = tileC + tid; t <= tileEnd; t += localSz) {
+                int tInTile = t - tileC;
+                float score = 0.0f;
+                for (int d = 0; d < headSize; d++) {
+                    score += qShared[d] * kTile[tInTile * headSize + d];
+                }
+                sTile[tInTile] = score / TornadoMath.sqrt(headSize);
+            }
+            context.localBarrier();
+
+            float tileMax = Float.NEGATIVE_INFINITY;
+            for (int t = 0; t <= tileEnd - tileC; t++) {
+                if (sTile[t] > tileMax) {
+                    tileMax = sTile[t];
+                }
+            }
+            if (tid == 0) {
+                maxHolder[0] = tileMax;
+            }
+            context.localBarrier();
+            float curTileMax = maxHolder[0];
+
+            float newMax = Math.max(maxScore, curTileMax);
+            if (newMax != maxScore && maxScore != Float.NEGATIVE_INFINITY) {
+                float scale = TornadoMath.exp(maxScore - newMax);
+                sumExp *= scale;
+                for (int d = 0; d < headSize; d++) {
+                    output[d] *= scale;
+                }
+            }
+            maxScore = newMax;
+
+            for (int t = 0; t <= tileEnd - tileC; t++) {
+                float expScore = TornadoMath.exp(sTile[t] - maxScore);
+                sumExp += expScore;
+                for (int d = 0; d < headSize; d++) {
+                    output[d] += expScore * vTile[t * headSize + d];
+                }
+            }
+            context.localBarrier();
+        }
+
+        float norm = (sumExp > 0.0f) ? (1.0f / sumExp) : 0.0f;
+        int xbOffset = batchIdx * dim + h * headSize;
+        for (int d = tid; d < headSize; d += localSz) {
+            wrapXbBatch.set(xbOffset + d, output[d] * norm);
+        }
+    }
+
     // ── Output / FFN Projections ─────────────────────────────────────────────
 
     /**
@@ -1483,6 +1598,178 @@ public final class TransformerBatchPrefillKernels {
 
             // Tile max: redundant per-thread scan over <= 16 shared values —
             // deterministic across the workgroup, no broadcast needed.
+            float tileMax = Float.NEGATIVE_INFINITY;
+            for (int t = 0; t < tileLen; t++) {
+                if (sTile[t] > tileMax) {
+                    tileMax = sTile[t];
+                }
+            }
+
+            float newMax = Math.max(maxScore, tileMax);
+            if (maxScore != Float.NEGATIVE_INFINITY && newMax != maxScore) {
+                float corr = TornadoMath.exp(maxScore - newMax);
+                sumExp *= corr;
+                acc0 *= corr;
+                acc1 *= corr;
+            }
+            maxScore = newMax;
+
+            for (int t = 0; t < tileLen; t++) {
+                float p = TornadoMath.exp(sTile[t] - maxScore);
+                sumExp += p;
+                acc0 += p * vTile[t * headSize + tid];
+                if (d1 < headSize) {
+                    acc1 += p * vTile[t * headSize + d1];
+                }
+            }
+            context.localBarrier();
+        }
+
+        float norm = (sumExp > 0.0f) ? (1.0f / sumExp) : 0.0f;
+        int outOffset = batchIdx * dim + h * headSize;
+        attnOutFP16.set(outOffset + tid, new HalfFloat(acc0 * norm));
+        if (d1 < headSize) {
+            attnOutFP16.set(outOffset + d1, new HalfFloat(acc1 * norm));
+        }
+    }
+
+    // ── Batched DECODE variants (per-slot KV cache + per-slot position) ──────
+    //
+    // These two kernels are the only semantic delta between batched PREFILL (B
+    // tokens of ONE sequence, shared causal KV) and batched DECODE (B independent
+    // sequences, each with its own KV region and its own position). The math is
+    // identical to the *Packed / *FP16Out prefill kernels above; only the KV
+    // addressing changes:
+    //   pos  = seqPositions[batchIdx]                                  (per slot)
+    //   base = batchIdx*(numLayers*ctx*kvDim) + layer*ctx*kvDim        (per slot)
+    // The KV cache is therefore sized B*numLayers*contextLength*kvDim.
+
+    /**
+     * Per-slot RoPE + KV-cache write over the packed QKV buffer (decode).
+     *
+     * <p>Fork of {@link #batchedRopeWithKVCachePacked}: each batch slot rotates at
+     * its own position {@code seqPositions[batchIdx]} and writes K/V into its own
+     * KV region ({@code batchIdx} stride = {@code numLayers*contextLength*kvDim}).</p>
+     */
+    public static void batchedDecodeRopeWithKVCachePacked(KernelContext context,
+                                                          IntArray seqPositions,
+                                                          FloatArray qkvBatch,
+                                                          FloatArray wrapKeyCache,
+                                                          FloatArray wrapValueCache,
+                                                          int kvDim, int headSize,
+                                                          int layerIndex, int numLayers,
+                                                          int contextLength, int dim) {
+        int globalIdx = context.globalIdx;
+        int halfDim = dim / 2;
+        int batchIdx = globalIdx / halfDim;
+        int pairIdx = globalIdx % halfDim;
+        int i = pairIdx * 2;
+        int qkvStride = dim + 2 * kvDim;
+
+        int pos = seqPositions.get(batchIdx);
+        int qOffset = batchIdx * qkvStride;
+        int kOffset = batchIdx * qkvStride + dim;
+        int vOffset = batchIdx * qkvStride + dim + kvDim;
+
+        if (i + 1 < dim) {
+            int head_dim = i % headSize;
+            float freq = 1.0f / TornadoMath.pow(50000.0f, head_dim / (float) headSize);
+            float val = pos * freq;
+            float fcr = TornadoMath.cos(val);
+            float fci = TornadoMath.sin(val);
+
+            float v0q = qkvBatch.get(qOffset + i);
+            float v1q = qkvBatch.get(qOffset + i + 1);
+            qkvBatch.set(qOffset + i, v0q * fcr - v1q * fci);
+            qkvBatch.set(qOffset + i + 1, v0q * fci + v1q * fcr);
+
+            if (i + 1 < kvDim) {
+                float v0k = qkvBatch.get(kOffset + i);
+                float v1k = qkvBatch.get(kOffset + i + 1);
+                float rotK0 = v0k * fcr - v1k * fci;
+                float rotK1 = v0k * fci + v1k * fcr;
+
+                int slotBase = batchIdx * (numLayers * contextLength * kvDim);
+                int cacheOff = slotBase + layerIndex * contextLength * kvDim + pos * kvDim;
+                wrapKeyCache.set(cacheOff + i, rotK0);
+                wrapKeyCache.set(cacheOff + i + 1, rotK1);
+                wrapValueCache.set(cacheOff + i, qkvBatch.get(vOffset + i));
+                wrapValueCache.set(cacheOff + i + 1, qkvBatch.get(vOffset + i + 1));
+            }
+        }
+    }
+
+    /**
+     * Per-slot flash attention over the packed QKV buffer, FP16 output (decode).
+     *
+     * <p>Fork of {@link #batchedFlashAttentionFP16Out}: each batch slot attends
+     * over {@code 0..seqPositions[batchIdx]} of its OWN KV region. Same
+     * register-partitioned P·V accumulation and FP16 emission.</p>
+     *
+     * <p>Requires headSize <= 2*localSz (localSz = min(headSize, 128)).</p>
+     */
+    public static void batchedDecodeAttentionFP16Out(KernelContext context,
+                                                     IntArray seqPositions,
+                                                     FloatArray qkvBatch,
+                                                     FloatArray wrapKeyCache,
+                                                     FloatArray wrapValueCache,
+                                                     HalfFloatArray attnOutFP16,
+                                                     int nHeads, int headSize,
+                                                     int kvDim, int kvMul,
+                                                     int layerIndex, int numLayers,
+                                                     int contextLength, int dim) {
+        int tid = context.localIdx;
+        int groupId = context.groupIdx;
+        int localSz = context.localGroupSizeX;
+
+        int batchIdx = groupId / nHeads;
+        int h = groupId % nHeads;
+        int pos = seqPositions.get(batchIdx);
+        int loff = batchIdx * (numLayers * contextLength * kvDim) + layerIndex * contextLength * kvDim;
+        int kvHeadIdx = h / kvMul;
+        int BLOCK_C = 16;
+        int qkvStride = dim + 2 * kvDim;
+
+        float[] qShared = context.allocateFloatLocalArray(headSize);
+        float[] kTile = context.allocateFloatLocalArray(BLOCK_C * headSize);
+        float[] vTile = context.allocateFloatLocalArray(BLOCK_C * headSize);
+        float[] sTile = context.allocateFloatLocalArray(BLOCK_C);
+
+        int qOffset = batchIdx * qkvStride + h * headSize;
+        for (int i = tid; i < headSize; i += localSz) {
+            qShared[i] = qkvBatch.get(qOffset + i);
+        }
+        context.localBarrier();
+
+        float maxScore = Float.NEGATIVE_INFINITY;
+        float sumExp = 0.0f;
+        float acc0 = 0.0f;
+        float acc1 = 0.0f;
+        int d1 = tid + localSz;
+
+        for (int tileC = 0; tileC <= pos; tileC += BLOCK_C) {
+            int tileEnd = Math.min(tileC + BLOCK_C - 1, pos);
+            int tileLen = tileEnd - tileC + 1;
+
+            for (int idx = tid; idx < tileLen * headSize; idx += localSz) {
+                int tInTile = idx / headSize;
+                int d = idx % headSize;
+                int kvOff = loff + (tileC + tInTile) * kvDim + kvHeadIdx * headSize + d;
+                kTile[tInTile * headSize + d] = wrapKeyCache.get(kvOff);
+                vTile[tInTile * headSize + d] = wrapValueCache.get(kvOff);
+            }
+            context.localBarrier();
+
+            for (int t = tileC + tid; t <= tileEnd; t += localSz) {
+                int tInTile = t - tileC;
+                float score = 0.0f;
+                for (int d = 0; d < headSize; d++) {
+                    score += qShared[d] * kTile[tInTile * headSize + d];
+                }
+                sTile[tInTile] = score / TornadoMath.sqrt(headSize);
+            }
+            context.localBarrier();
+
             float tileMax = Float.NEGATIVE_INFINITY;
             for (int t = 0; t < tileLen; t++) {
                 if (sTile[t] > tileMax) {

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/LlamaFP16LayersBatchDecodeMMA.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/LlamaFP16LayersBatchDecodeMMA.java
@@ -1,0 +1,256 @@
+package org.beehive.gpullama3.tornadovm.layers.type.fp16.decode;
+
+import org.beehive.gpullama3.inference.state.LlamaState;
+import org.beehive.gpullama3.inference.weights.tornado.LlamaTornadoWeights;
+import org.beehive.gpullama3.model.llama.LlamaConfiguration;
+import org.beehive.gpullama3.tornadovm.kernels.TransformerBatchPrefillKernels;
+import org.beehive.gpullama3.tornadovm.scheduling.WorkerGridFactory;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.WorkerGrid2D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * Batched-DECODE transformer-layer TaskGraphs: B independent sequences advancing
+ * one token per step, each with its own KV region and its own position.
+ *
+ * <p>Structurally identical to {@code LlamaFP16LayersBatchPrefillMMA} (same 12-task
+ * MMA pipeline: RMS → fused QKV GEMM → RoPE+KV → flash attention → Wo → FFN RMS →
+ * fused gate/up GEMM → SwiGLU → W2 → residual). The only differences are the two
+ * KV-addressing kernels, which take a per-slot position array and a B-sized KV
+ * cache ({@code batchIdx} stride = {@code numLayers*contextLength*kvDim}):</p>
+ * <ul>
+ *   <li>{@code batch_rope_kv} → {@link TransformerBatchPrefillKernels#batchedDecodeRopeWithKVCachePacked}</li>
+ *   <li>{@code batch_attention} → {@link TransformerBatchPrefillKernels#batchedDecodeAttentionFP16Out}</li>
+ * </ul>
+ *
+ * <p>The KV cache and {@code seqPositions} are supplied by the engine (not State),
+ * so the context length can be capped independently to fit B×L×ctx×kvDim in VRAM.</p>
+ */
+public class LlamaFP16LayersBatchDecodeMMA {
+
+    static final int RMS_LOCAL_SIZE = 256;
+
+    private final LlamaState state;
+    private final LlamaTornadoWeights weights;
+    private final LlamaConfiguration config;
+    private final KernelContext context = new KernelContext();
+    private final int batchSize;
+    private final int paddedBatch;
+    private final int decodeCtx;
+    private final FloatArray keyCacheBatch;
+    private final FloatArray valueCacheBatch;
+    private final IntArray seqPositions;
+    private final List<ImmutableTaskGraph> layerITGs;
+    private String lastLayerTaskGraphID;
+
+    public LlamaFP16LayersBatchDecodeMMA(LlamaState state, LlamaTornadoWeights weights,
+                                         LlamaConfiguration config, int batchSize, int decodeCtx,
+                                         FloatArray keyCacheBatch, FloatArray valueCacheBatch,
+                                         IntArray seqPositions) {
+        this.state = state;
+        this.weights = weights;
+        this.config = config;
+        this.batchSize = batchSize;
+        this.paddedBatch = (batchSize + 127) & ~127;
+        this.decodeCtx = decodeCtx;
+        this.keyCacheBatch = keyCacheBatch;
+        this.valueCacheBatch = valueCacheBatch;
+        this.seqPositions = seqPositions;
+        this.layerITGs = IntStream.range(0, config.numberOfLayers())
+                .mapToObj(this::createLayerTaskGraph)
+                .map(TaskGraph::snapshot)
+                .toList();
+    }
+
+    // @formatter:off
+    private TaskGraph createLayerTaskGraph(int layerIndex) {
+        String graphName = "batchDecodeLayer_" + layerIndex;
+        if (layerIndex == config.numberOfLayers() - 1) lastLayerTaskGraphID = graphName;
+
+        TaskGraph g = new TaskGraph(graphName);
+
+        if (layerIndex == 0) {
+            // Per-slot positions change every decode step.
+            g.transferToDevice(DataTransferMode.EVERY_EXECUTION, seqPositions);
+            g.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                    context,
+                    state.attnScaleBatch, state.ffnScaleBatch,
+                    state.wrapXbFP16Batch,
+                    state.qkvResultBatch,
+                    keyCacheBatch, valueCacheBatch,
+                    state.normedXFFNFP16, state.gateUpResultBatch,
+                    state.attnOutFP16, state.woOut, state.wrapHbFP16Batch, state.w2Out);
+            g.consumeFromDevice("prefillActivation", state.wrapXBatch);
+        } else {
+            String pred = "batchDecodeLayer_" + (layerIndex - 1);
+            g.consumeFromDevice(pred,
+                    context,
+                    state.wrapXBatch,
+                    seqPositions,
+                    state.attnScaleBatch, state.ffnScaleBatch,
+                    state.wrapXbFP16Batch,
+                    state.qkvResultBatch,
+                    keyCacheBatch, valueCacheBatch,
+                    state.normedXFFNFP16, state.gateUpResultBatch,
+                    state.attnOutFP16, state.woOut, state.wrapHbFP16Batch, state.w2Out);
+        }
+
+        g.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                weights.rms_att_weightLayered[layerIndex].asFloatArray(),
+                weights.wqLayered[layerIndex].asHalfFloatArray(),
+                weights.wkLayered[layerIndex].asHalfFloatArray(),
+                weights.wvLayered[layerIndex].asHalfFloatArray(),
+                weights.woLayered[layerIndex].asHalfFloatArray(),
+                weights.rms_ffn_weightLayered[layerIndex].asFloatArray(),
+                weights.w1Layered[layerIndex].asHalfFloatArray(),
+                weights.w2Layered[layerIndex].asHalfFloatArray(),
+                weights.w3Layered[layerIndex].asHalfFloatArray());
+
+        int dim    = config.dim();
+        int kvDim  = config.kvDim();
+        int hidDim = config.hiddenDim();
+
+        g.task("batch_attn_rms",
+                TransformerBatchPrefillKernels::batchedRmsReduceParallel,
+                context, state.wrapXBatch, state.attnScaleBatch,
+                dim, config.rmsNormEps(), RMS_LOCAL_SIZE);
+
+        g.task("batch_attn_rms_apply",
+                TransformerBatchPrefillKernels::batchedRmsApplyFP16,
+                context, state.wrapXbFP16Batch, state.wrapXBatch,
+                weights.rms_att_weightLayered[layerIndex].asFloatArray(),
+                state.attnScaleBatch, dim);
+
+        g.task("qkvProj",
+                TransformerBatchPrefillKernels::gemmMMAQKV,
+                context, state.wrapXbFP16Batch,
+                weights.wqLayered[layerIndex].asHalfFloatArray(),
+                weights.wkLayered[layerIndex].asHalfFloatArray(),
+                weights.wvLayered[layerIndex].asHalfFloatArray(),
+                state.qkvResultBatch, paddedBatch, dim, kvDim, dim);
+
+        // DECODE: per-slot position + per-slot KV region.
+        g.task("batch_rope_kv",
+                TransformerBatchPrefillKernels::batchedDecodeRopeWithKVCachePacked,
+                context, seqPositions,
+                state.qkvResultBatch,
+                keyCacheBatch, valueCacheBatch,
+                kvDim, config.headSize(), layerIndex, config.numberOfLayers(), decodeCtx, dim);
+
+        g.task("batch_attention",
+                TransformerBatchPrefillKernels::batchedDecodeAttentionFP16Out,
+                context, seqPositions,
+                state.qkvResultBatch, keyCacheBatch, valueCacheBatch,
+                state.attnOutFP16,
+                config.numberOfHeads(), config.headSize(),
+                kvDim, config.kvMul(), layerIndex, config.numberOfLayers(), decodeCtx, dim);
+
+        g.task("woProj", TransformerBatchPrefillKernels::gemmMMA,
+                context, state.attnOutFP16,
+                weights.woLayered[layerIndex].asHalfFloatArray(),
+                state.woOut, paddedBatch, dim, dim);
+
+        g.task("batch_ffn_rms",
+                TransformerBatchPrefillKernels::batchedRmsReduceFusedResidual,
+                context, state.wrapXBatch, state.woOut, state.ffnScaleBatch,
+                dim, config.rmsNormEps(), RMS_LOCAL_SIZE);
+
+        g.task("batch_ffn_rms_apply",
+                TransformerBatchPrefillKernels::batchedFFNRmsApplyFP16,
+                context, state.normedXFFNFP16, state.wrapXBatch,
+                weights.rms_ffn_weightLayered[layerIndex].asFloatArray(),
+                state.ffnScaleBatch, dim);
+
+        g.task("gateUpProj",
+                TransformerBatchPrefillKernels::gemmMMAGateUp,
+                context, state.normedXFFNFP16,
+                weights.w1Layered[layerIndex].asHalfFloatArray(),
+                weights.w3Layered[layerIndex].asHalfFloatArray(),
+                state.gateUpResultBatch, paddedBatch, hidDim, dim);
+
+        g.task("swiglu",
+                TransformerBatchPrefillKernels::batchedFFNSwiGLUFP16Packed,
+                        context, state.wrapHbFP16Batch, state.gateUpResultBatch, hidDim)
+         .task("w2Proj", TransformerBatchPrefillKernels::gemmMMA,
+                        context, state.wrapHbFP16Batch,
+                        weights.w2Layered[layerIndex].asHalfFloatArray(),
+                        state.w2Out, batchSize, dim, hidDim)
+         .task("w2Resid", TransformerBatchPrefillKernels::batchedResidualAddFP32,
+                        context, state.wrapXBatch, state.w2Out);
+
+        g.persistOnDevice(state.wrapXBatch, keyCacheBatch, valueCacheBatch);
+        return g;
+    }
+    // @formatter:on
+
+    static WorkerGrid mmaGrid(int paddedM, int N) {
+        int mBlocks = paddedM / 128;
+        int nBlocks = N / 128;
+        WorkerGrid2D grid = new WorkerGrid2D(mBlocks * 256, nBlocks);
+        grid.setLocalWork(256, 1, 1);
+        return grid;
+    }
+
+    static WorkerGrid elementwiseGrid(int n) {
+        WorkerGrid1D grid = new WorkerGrid1D(n);
+        grid.setLocalWork(256, 1, 1);
+        return grid;
+    }
+
+    public void updateGridScheduler(GridScheduler scheduler) {
+        int dim    = config.dim();
+        int kvDim  = config.kvDim();
+        int hidDim = config.hiddenDim();
+        int nHeads = config.numberOfHeads();
+        int headSz = config.headSize();
+
+        WorkerGrid rmsWorker = WorkerGridFactory.genericWorker(batchSize * RMS_LOCAL_SIZE, RMS_LOCAL_SIZE);
+        WorkerGrid rmsApplyWorker    = WorkerGridFactory.genericWorker(batchSize * dim, 256);
+        WorkerGrid ffnRmsApplyWorker = WorkerGridFactory.genericWorker(batchSize * dim, 256);
+
+        int ropeGlobal = batchSize * (dim / 2);
+        int ropeLocal  = Math.min(512, ropeGlobal);
+        while (ropeLocal > 1 && ropeGlobal % ropeLocal != 0) ropeLocal--;
+        WorkerGrid ropeWorker = WorkerGridFactory.genericWorker(ropeGlobal, ropeLocal);
+
+        int attnLocal = Math.min(headSz, 128);
+        WorkerGrid attnWorker = WorkerGridFactory.genericWorker(batchSize * nHeads * attnLocal, attnLocal);
+
+        WorkerGrid mmaQkvWorker    = mmaGrid(paddedBatch, dim + 2 * kvDim);
+        WorkerGrid mmaDimWorker    = mmaGrid(paddedBatch, dim);
+        WorkerGrid mmaGateUpWorker = mmaGrid(paddedBatch, 2 * hidDim);
+
+        WorkerGrid ewDimWorker = elementwiseGrid(batchSize * dim);
+        WorkerGrid ewHidWorker = elementwiseGrid(batchSize * hidDim);
+
+        for (int i = 0; i < config.numberOfLayers(); i++) {
+            String p = "batchDecodeLayer_" + i + ".";
+            scheduler.addWorkerGrid(p + "batch_attn_rms",       rmsWorker);
+            scheduler.addWorkerGrid(p + "batch_attn_rms_apply", rmsApplyWorker);
+            scheduler.addWorkerGrid(p + "qkvProj",              mmaQkvWorker);
+            scheduler.addWorkerGrid(p + "batch_rope_kv",        ropeWorker);
+            scheduler.addWorkerGrid(p + "batch_attention",      attnWorker);
+            scheduler.addWorkerGrid(p + "woProj",               mmaDimWorker);
+            scheduler.addWorkerGrid(p + "batch_ffn_rms",        rmsWorker);
+            scheduler.addWorkerGrid(p + "batch_ffn_rms_apply",  ffnRmsApplyWorker);
+            scheduler.addWorkerGrid(p + "gateUpProj",           mmaGateUpWorker);
+            scheduler.addWorkerGrid(p + "swiglu",               ewHidWorker);
+            scheduler.addWorkerGrid(p + "w2Proj",               mmaDimWorker);
+            scheduler.addWorkerGrid(p + "w2Resid",              ewDimWorker);
+        }
+    }
+
+    public List<ImmutableTaskGraph> getLayerImmutableTaskGraphs() { return layerITGs; }
+    public String getLastLayerTaskGraphID()                        { return lastLayerTaskGraphID; }
+    public KernelContext getContext()                              { return context; }
+}

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/LlamaFP16LayersBatchDecodeMMA.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/LlamaFP16LayersBatchDecodeMMA.java
@@ -50,6 +50,11 @@ public class LlamaFP16LayersBatchDecodeMMA {
     private final FloatArray keyCacheBatch;
     private final FloatArray valueCacheBatch;
     private final IntArray seqPositions;
+    // Paging (optional): when blockTable != null, KV is addressed through a block table.
+    private final boolean paged;
+    private final IntArray blockTable;
+    private final int blockSize;
+    private final int maxBlocksPerSlot;
     private final List<ImmutableTaskGraph> layerITGs;
     private String lastLayerTaskGraphID;
 
@@ -57,6 +62,16 @@ public class LlamaFP16LayersBatchDecodeMMA {
                                          LlamaConfiguration config, int batchSize, int decodeCtx,
                                          FloatArray keyCacheBatch, FloatArray valueCacheBatch,
                                          IntArray seqPositions) {
+        this(state, weights, config, batchSize, decodeCtx, keyCacheBatch, valueCacheBatch, seqPositions,
+                null, 0, 0);
+    }
+
+    /** Paged constructor: keyCacheBatch/valueCacheBatch are the shared block pools. */
+    public LlamaFP16LayersBatchDecodeMMA(LlamaState state, LlamaTornadoWeights weights,
+                                         LlamaConfiguration config, int batchSize, int decodeCtx,
+                                         FloatArray keyCacheBatch, FloatArray valueCacheBatch,
+                                         IntArray seqPositions,
+                                         IntArray blockTable, int blockSize, int maxBlocksPerSlot) {
         this.state = state;
         this.weights = weights;
         this.config = config;
@@ -66,6 +81,10 @@ public class LlamaFP16LayersBatchDecodeMMA {
         this.keyCacheBatch = keyCacheBatch;
         this.valueCacheBatch = valueCacheBatch;
         this.seqPositions = seqPositions;
+        this.paged = blockTable != null;
+        this.blockTable = blockTable;
+        this.blockSize = blockSize;
+        this.maxBlocksPerSlot = maxBlocksPerSlot;
         this.layerITGs = IntStream.range(0, config.numberOfLayers())
                 .mapToObj(this::createLayerTaskGraph)
                 .map(TaskGraph::snapshot)
@@ -82,6 +101,9 @@ public class LlamaFP16LayersBatchDecodeMMA {
         if (layerIndex == 0) {
             // Per-slot positions change every decode step.
             g.transferToDevice(DataTransferMode.EVERY_EXECUTION, seqPositions);
+            if (paged) {
+                g.transferToDevice(DataTransferMode.EVERY_EXECUTION, blockTable);
+            }
             g.transferToDevice(DataTransferMode.FIRST_EXECUTION,
                     context,
                     state.attnScaleBatch, state.ffnScaleBatch,
@@ -93,6 +115,9 @@ public class LlamaFP16LayersBatchDecodeMMA {
             g.consumeFromDevice("prefillActivation", state.wrapXBatch);
         } else {
             String pred = "batchDecodeLayer_" + (layerIndex - 1);
+            if (paged) {
+                g.consumeFromDevice(pred, context, blockTable);
+            }
             g.consumeFromDevice(pred,
                     context,
                     state.wrapXBatch,
@@ -139,21 +164,40 @@ public class LlamaFP16LayersBatchDecodeMMA {
                 weights.wvLayered[layerIndex].asHalfFloatArray(),
                 state.qkvResultBatch, paddedBatch, dim, kvDim, dim);
 
-        // DECODE: per-slot position + per-slot KV region.
-        g.task("batch_rope_kv",
-                TransformerBatchPrefillKernels::batchedDecodeRopeWithKVCachePacked,
-                context, seqPositions,
-                state.qkvResultBatch,
-                keyCacheBatch, valueCacheBatch,
-                kvDim, config.headSize(), layerIndex, config.numberOfLayers(), decodeCtx, dim);
+        // DECODE: per-slot position + per-slot KV region (paged via block table, or contiguous).
+        if (paged) {
+            int blockCfg = blockSize | (maxBlocksPerSlot << 16);
+            g.task("batch_rope_kv",
+                    TransformerBatchPrefillKernels::batchedDecodePagedRopeWithKVCachePacked,
+                    context, seqPositions, blockTable,
+                    state.qkvResultBatch, keyCacheBatch, valueCacheBatch,
+                    kvDim, config.headSize(), layerIndex, config.numberOfLayers(),
+                    blockCfg, dim);
 
-        g.task("batch_attention",
-                TransformerBatchPrefillKernels::batchedDecodeAttentionFP16Out,
-                context, seqPositions,
-                state.qkvResultBatch, keyCacheBatch, valueCacheBatch,
-                state.attnOutFP16,
-                config.numberOfHeads(), config.headSize(),
-                kvDim, config.kvMul(), layerIndex, config.numberOfLayers(), decodeCtx, dim);
+            g.task("batch_attention",
+                    TransformerBatchPrefillKernels::batchedDecodePagedAttentionFP16Out,
+                    context, seqPositions, blockTable,
+                    state.qkvResultBatch, keyCacheBatch, valueCacheBatch,
+                    state.attnOutFP16,
+                    config.numberOfHeads(), config.headSize(),
+                    kvDim, config.kvMul(), layerIndex, config.numberOfLayers(),
+                    blockCfg);
+        } else {
+            g.task("batch_rope_kv",
+                    TransformerBatchPrefillKernels::batchedDecodeRopeWithKVCachePacked,
+                    context, seqPositions,
+                    state.qkvResultBatch,
+                    keyCacheBatch, valueCacheBatch,
+                    kvDim, config.headSize(), layerIndex, config.numberOfLayers(), decodeCtx, dim);
+
+            g.task("batch_attention",
+                    TransformerBatchPrefillKernels::batchedDecodeAttentionFP16Out,
+                    context, seqPositions,
+                    state.qkvResultBatch, keyCacheBatch, valueCacheBatch,
+                    state.attnOutFP16,
+                    config.numberOfHeads(), config.headSize(),
+                    kvDim, config.kvMul(), layerIndex, config.numberOfLayers(), decodeCtx, dim);
+        }
 
         g.task("woProj", TransformerBatchPrefillKernels::gemmMMA,
                 context, state.attnOutFP16,

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/Qwen3FP16LayersBatchDecodeMMA.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/Qwen3FP16LayersBatchDecodeMMA.java
@@ -51,6 +51,10 @@ public class Qwen3FP16LayersBatchDecodeMMA {
     private final FloatArray keyCacheBatch;
     private final FloatArray valueCacheBatch;
     private final IntArray seqPositions;
+    private final boolean paged;
+    private final IntArray blockTable;
+    private final int blockSize;
+    private final int maxBlocksPerSlot;
     private final List<ImmutableTaskGraph> layerITGs;
     private String lastLayerTaskGraphID;
 
@@ -58,6 +62,20 @@ public class Qwen3FP16LayersBatchDecodeMMA {
                                          Qwen3Configuration config, int batchSize, int decodeCtx,
                                          FloatArray keyCacheBatch, FloatArray valueCacheBatch,
                                          IntArray seqPositions) {
+        this(state, weights, config, batchSize, decodeCtx, keyCacheBatch, valueCacheBatch, seqPositions,
+                null, 0, 0);
+    }
+
+    /** Paged constructor: keyCacheBatch/valueCacheBatch are the shared block pools. */
+    public Qwen3FP16LayersBatchDecodeMMA(Qwen3State state, Qwen3TornadoWeights weights,
+                                         Qwen3Configuration config, int batchSize, int decodeCtx,
+                                         FloatArray keyCacheBatch, FloatArray valueCacheBatch,
+                                         IntArray seqPositions,
+                                         IntArray blockTable, int blockSize, int maxBlocksPerSlot) {
+        this.paged = blockTable != null;
+        this.blockTable = blockTable;
+        this.blockSize = blockSize;
+        this.maxBlocksPerSlot = maxBlocksPerSlot;
         this.state = state;
         this.weights = weights;
         this.config = config;
@@ -89,6 +107,9 @@ public class Qwen3FP16LayersBatchDecodeMMA {
 
         if (layerIndex == 0) {
             g.transferToDevice(DataTransferMode.EVERY_EXECUTION, seqPositions);
+            if (paged) {
+                g.transferToDevice(DataTransferMode.EVERY_EXECUTION, blockTable);
+            }
             g.transferToDevice(DataTransferMode.FIRST_EXECUTION,
                     context,
                     state.attnScaleBatch, state.ffnScaleBatch,
@@ -100,6 +121,9 @@ public class Qwen3FP16LayersBatchDecodeMMA {
             g.consumeFromDevice("prefillActivation", state.wrapXBatch);
         } else {
             String pred = "batchDecodeLayer_" + (layerIndex - 1);
+            if (paged) {
+                g.consumeFromDevice(pred, context, blockTable);
+            }
             g.consumeFromDevice(pred,
                     context,
                     state.wrapXBatch,
@@ -153,21 +177,39 @@ public class Qwen3FP16LayersBatchDecodeMMA {
                 config.numberOfHeads(), nHeadKv, nEmbdHead,
                 qDim, kvDim, config.rmsNormEps());
 
-        // DECODE: per-slot position + per-slot KV region.
-        g.task("batch_rope_kv",
-                Qwen3Kernels::batchedDecodeRopeWithKVCacheQwen3Packed,
-                context, seqPositions,
-                state.qkvResultBatch,
-                keyCacheBatch, valueCacheBatch,
-                kvDim, nEmbdHead, layerIndex, config.numberOfLayers(), decodeCtx, qDim);
+        // DECODE: per-slot position + per-slot KV region (paged via block table, or contiguous).
+        if (paged) {
+            int blockCfg = blockSize | (maxBlocksPerSlot << 16);
+            g.task("batch_rope_kv",
+                    Qwen3Kernels::batchedDecodePagedRopeWithKVCacheQwen3Packed,
+                    context, seqPositions, blockTable,
+                    state.qkvResultBatch, keyCacheBatch, valueCacheBatch,
+                    kvDim, nEmbdHead, layerIndex, config.numberOfLayers(), blockCfg, qDim);
 
-        g.task("batch_attention",
-                TransformerBatchPrefillKernels::batchedDecodeAttentionFP16Out,
-                context, seqPositions,
-                state.qkvResultBatch, keyCacheBatch, valueCacheBatch,
-                state.attnOutFP16,
-                config.numberOfHeads(), nEmbdHead,
-                kvDim, gqa, layerIndex, config.numberOfLayers(), decodeCtx, qDim);
+            // Shared paged attention: qDim == nHeads*nEmbdHead for Qwen3.
+            g.task("batch_attention",
+                    TransformerBatchPrefillKernels::batchedDecodePagedAttentionFP16Out,
+                    context, seqPositions, blockTable,
+                    state.qkvResultBatch, keyCacheBatch, valueCacheBatch,
+                    state.attnOutFP16,
+                    config.numberOfHeads(), nEmbdHead,
+                    kvDim, gqa, layerIndex, config.numberOfLayers(), blockCfg);
+        } else {
+            g.task("batch_rope_kv",
+                    Qwen3Kernels::batchedDecodeRopeWithKVCacheQwen3Packed,
+                    context, seqPositions,
+                    state.qkvResultBatch,
+                    keyCacheBatch, valueCacheBatch,
+                    kvDim, nEmbdHead, layerIndex, config.numberOfLayers(), decodeCtx, qDim);
+
+            g.task("batch_attention",
+                    TransformerBatchPrefillKernels::batchedDecodeAttentionFP16Out,
+                    context, seqPositions,
+                    state.qkvResultBatch, keyCacheBatch, valueCacheBatch,
+                    state.attnOutFP16,
+                    config.numberOfHeads(), nEmbdHead,
+                    kvDim, gqa, layerIndex, config.numberOfLayers(), decodeCtx, qDim);
+        }
 
         g.task("woProj", TransformerBatchPrefillKernels::gemmMMA,
                 context, state.attnOutFP16,

--- a/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/Qwen3FP16LayersBatchDecodeMMA.java
+++ b/src/main/java/org/beehive/gpullama3/tornadovm/layers/type/fp16/decode/Qwen3FP16LayersBatchDecodeMMA.java
@@ -1,0 +1,272 @@
+package org.beehive.gpullama3.tornadovm.layers.type.fp16.decode;
+
+import org.beehive.gpullama3.inference.state.Qwen3State;
+import org.beehive.gpullama3.inference.weights.tornado.Qwen3TornadoWeights;
+import org.beehive.gpullama3.model.qwen3.Qwen3Configuration;
+import org.beehive.gpullama3.tornadovm.kernels.Qwen3Kernels;
+import org.beehive.gpullama3.tornadovm.kernels.TransformerBatchPrefillKernels;
+import org.beehive.gpullama3.tornadovm.scheduling.WorkerGridFactory;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.WorkerGrid2D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * Qwen3 batched-DECODE transformer-layer TaskGraphs: B independent sequences, each
+ * with its own KV region and position.
+ *
+ * <p>Structurally identical to {@link org.beehive.gpullama3.tornadovm.layers.type.fp16.prefill.Qwen3FP16LayersBatchPrefillMMA}
+ * (13-task MMA pipeline including the Qwen3 per-head Q/K RMS norm). Swaps the two
+ * KV-addressing kernels for the per-slot decode variants over a B-sized KV cache:</p>
+ * <ul>
+ *   <li>{@code batch_rope_kv} → {@link Qwen3Kernels#batchedDecodeRopeWithKVCacheQwen3Packed}</li>
+ *   <li>{@code batch_attention} → {@link TransformerBatchPrefillKernels#batchedDecodeAttentionFP16Out}</li>
+ * </ul>
+ */
+public class Qwen3FP16LayersBatchDecodeMMA {
+
+    static final int RMS_LOCAL_SIZE = 256;
+
+    private final Qwen3State state;
+    private final Qwen3TornadoWeights weights;
+    private final Qwen3Configuration config;
+    private final KernelContext context = new KernelContext();
+    private final int batchSize;
+    private final int paddedBatch;
+    private final int decodeCtx;
+    private final int nHeadKv;
+    private final int nEmbdHead;
+    private final int qDim;
+    private final int kvDim;
+    private final int gqa;
+    private final FloatArray keyCacheBatch;
+    private final FloatArray valueCacheBatch;
+    private final IntArray seqPositions;
+    private final List<ImmutableTaskGraph> layerITGs;
+    private String lastLayerTaskGraphID;
+
+    public Qwen3FP16LayersBatchDecodeMMA(Qwen3State state, Qwen3TornadoWeights weights,
+                                         Qwen3Configuration config, int batchSize, int decodeCtx,
+                                         FloatArray keyCacheBatch, FloatArray valueCacheBatch,
+                                         IntArray seqPositions) {
+        this.state = state;
+        this.weights = weights;
+        this.config = config;
+        this.batchSize = batchSize;
+        this.paddedBatch = (batchSize + 127) & ~127;
+        this.decodeCtx = decodeCtx;
+        this.keyCacheBatch = keyCacheBatch;
+        this.valueCacheBatch = valueCacheBatch;
+        this.seqPositions = seqPositions;
+        this.nHeadKv = config.numberOfKeyValueHeads();
+        this.nEmbdHead = config.numberOfHeadsValue();
+        this.qDim = config.numberOfHeadsKey() * config.numberOfHeads();
+        this.kvDim = config.numberOfHeadsValue() * nHeadKv;
+        this.gqa = config.numberOfHeads() / nHeadKv;
+        this.layerITGs = IntStream.range(0, config.numberOfLayers())
+                .mapToObj(this::createLayerTaskGraph)
+                .map(TaskGraph::snapshot)
+                .toList();
+    }
+
+    // @formatter:off
+    private TaskGraph createLayerTaskGraph(int layerIndex) {
+        String graphName = "batchDecodeLayer_" + layerIndex;
+        if (layerIndex == config.numberOfLayers() - 1) lastLayerTaskGraphID = graphName;
+
+        TaskGraph g = new TaskGraph(graphName);
+        int dim    = config.dim();
+        int hidDim = config.hiddenDim();
+
+        if (layerIndex == 0) {
+            g.transferToDevice(DataTransferMode.EVERY_EXECUTION, seqPositions);
+            g.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                    context,
+                    state.attnScaleBatch, state.ffnScaleBatch,
+                    state.wrapXbFP16Batch,
+                    state.qkvResultBatch,
+                    keyCacheBatch, valueCacheBatch,
+                    state.normedXFFNFP16, state.gateUpResultBatch,
+                    state.attnOutFP16, state.woOut, state.wrapHbFP16Batch, state.w2Out);
+            g.consumeFromDevice("prefillActivation", state.wrapXBatch);
+        } else {
+            String pred = "batchDecodeLayer_" + (layerIndex - 1);
+            g.consumeFromDevice(pred,
+                    context,
+                    state.wrapXBatch,
+                    seqPositions,
+                    state.attnScaleBatch, state.ffnScaleBatch,
+                    state.wrapXbFP16Batch,
+                    state.qkvResultBatch,
+                    keyCacheBatch, valueCacheBatch,
+                    state.normedXFFNFP16, state.gateUpResultBatch,
+                    state.attnOutFP16, state.woOut, state.wrapHbFP16Batch, state.w2Out);
+        }
+
+        g.transferToDevice(DataTransferMode.FIRST_EXECUTION,
+                weights.rms_att_weightLayered[layerIndex].asFloatArray(),
+                weights.wqLayered[layerIndex].asHalfFloatArray(),
+                weights.wkLayered[layerIndex].asHalfFloatArray(),
+                weights.wvLayered[layerIndex].asHalfFloatArray(),
+                weights.woLayered[layerIndex].asHalfFloatArray(),
+                weights.rms_att_QNormLayered[layerIndex].asFloatArray(),
+                weights.rms_att_KNormLayered[layerIndex].asFloatArray(),
+                weights.rms_ffn_weightLayered[layerIndex].asFloatArray(),
+                weights.w1Layered[layerIndex].asHalfFloatArray(),
+                weights.w2Layered[layerIndex].asHalfFloatArray(),
+                weights.w3Layered[layerIndex].asHalfFloatArray());
+
+        g.task("batch_attn_rms",
+                TransformerBatchPrefillKernels::batchedRmsReduceParallel,
+                context, state.wrapXBatch, state.attnScaleBatch,
+                dim, config.rmsNormEps(), RMS_LOCAL_SIZE);
+
+        g.task("batch_attn_rms_apply",
+                TransformerBatchPrefillKernels::batchedRmsApplyFP16,
+                context, state.wrapXbFP16Batch, state.wrapXBatch,
+                weights.rms_att_weightLayered[layerIndex].asFloatArray(),
+                state.attnScaleBatch, dim);
+
+        g.task("qkvProj",
+                TransformerBatchPrefillKernels::gemmMMAQKV,
+                context, state.wrapXbFP16Batch,
+                weights.wqLayered[layerIndex].asHalfFloatArray(),
+                weights.wkLayered[layerIndex].asHalfFloatArray(),
+                weights.wvLayered[layerIndex].asHalfFloatArray(),
+                state.qkvResultBatch, paddedBatch, qDim, kvDim, dim);
+
+        // Qwen3: per-head Q/K RMS norm before RoPE (per-token, no KV → reused as-is).
+        g.task("batch_qk_rmsnorm",
+                Qwen3Kernels::batchedFusedQKRmsNormPacked,
+                context, state.qkvResultBatch,
+                weights.rms_att_QNormLayered[layerIndex].asFloatArray(),
+                weights.rms_att_KNormLayered[layerIndex].asFloatArray(),
+                config.numberOfHeads(), nHeadKv, nEmbdHead,
+                qDim, kvDim, config.rmsNormEps());
+
+        // DECODE: per-slot position + per-slot KV region.
+        g.task("batch_rope_kv",
+                Qwen3Kernels::batchedDecodeRopeWithKVCacheQwen3Packed,
+                context, seqPositions,
+                state.qkvResultBatch,
+                keyCacheBatch, valueCacheBatch,
+                kvDim, nEmbdHead, layerIndex, config.numberOfLayers(), decodeCtx, qDim);
+
+        g.task("batch_attention",
+                TransformerBatchPrefillKernels::batchedDecodeAttentionFP16Out,
+                context, seqPositions,
+                state.qkvResultBatch, keyCacheBatch, valueCacheBatch,
+                state.attnOutFP16,
+                config.numberOfHeads(), nEmbdHead,
+                kvDim, gqa, layerIndex, config.numberOfLayers(), decodeCtx, qDim);
+
+        g.task("woProj", TransformerBatchPrefillKernels::gemmMMA,
+                context, state.attnOutFP16,
+                weights.woLayered[layerIndex].asHalfFloatArray(),
+                state.woOut, paddedBatch, dim, qDim);
+
+        g.task("batch_ffn_rms",
+                TransformerBatchPrefillKernels::batchedRmsReduceFusedResidual,
+                context, state.wrapXBatch, state.woOut, state.ffnScaleBatch,
+                dim, config.rmsNormEps(), RMS_LOCAL_SIZE);
+
+        g.task("batch_ffn_rms_apply",
+                TransformerBatchPrefillKernels::batchedFFNRmsApplyFP16,
+                context, state.normedXFFNFP16, state.wrapXBatch,
+                weights.rms_ffn_weightLayered[layerIndex].asFloatArray(),
+                state.ffnScaleBatch, dim);
+
+        g.task("gateUpProj",
+                TransformerBatchPrefillKernels::gemmMMAGateUp,
+                context, state.normedXFFNFP16,
+                weights.w1Layered[layerIndex].asHalfFloatArray(),
+                weights.w3Layered[layerIndex].asHalfFloatArray(),
+                state.gateUpResultBatch, paddedBatch, hidDim, dim);
+
+        g.task("swiglu",
+                TransformerBatchPrefillKernels::batchedFFNSwiGLUFP16Packed,
+                        context, state.wrapHbFP16Batch, state.gateUpResultBatch, hidDim)
+         .task("w2Proj", TransformerBatchPrefillKernels::gemmMMA,
+                        context, state.wrapHbFP16Batch,
+                        weights.w2Layered[layerIndex].asHalfFloatArray(),
+                        state.w2Out, paddedBatch, dim, hidDim)
+         .task("w2Resid", TransformerBatchPrefillKernels::batchedResidualAddFP32,
+                        context, state.wrapXBatch, state.w2Out);
+
+        g.persistOnDevice(state.wrapXBatch, keyCacheBatch, valueCacheBatch);
+        return g;
+    }
+    // @formatter:on
+
+    static WorkerGrid mmaGrid(int paddedM, int N) {
+        int mBlocks = paddedM / 128;
+        int nBlocks = N / 128;
+        WorkerGrid2D grid = new WorkerGrid2D(mBlocks * 256, nBlocks);
+        grid.setLocalWork(256, 1, 1);
+        return grid;
+    }
+
+    static WorkerGrid elementwiseGrid(int n) {
+        WorkerGrid1D grid = new WorkerGrid1D(n);
+        grid.setLocalWork(256, 1, 1);
+        return grid;
+    }
+
+    public void updateGridScheduler(GridScheduler scheduler) {
+        int dim    = config.dim();
+        int hidDim = config.hiddenDim();
+        int nHeads = config.numberOfHeads();
+
+        WorkerGrid rmsWorker = WorkerGridFactory.genericWorker(batchSize * RMS_LOCAL_SIZE, RMS_LOCAL_SIZE);
+        WorkerGrid rmsApplyWorker    = WorkerGridFactory.genericWorker(batchSize * dim, 256);
+        WorkerGrid ffnRmsApplyWorker = WorkerGridFactory.genericWorker(batchSize * dim, 256);
+
+        WorkerGrid qkRmsNormWorker = WorkerGridFactory.genericWorker(
+                batchSize * (nHeads + nHeadKv) * nEmbdHead, nEmbdHead);
+
+        int ropeGlobal = batchSize * (qDim / 2);
+        int ropeLocal  = Math.min(512, ropeGlobal);
+        while (ropeLocal > 1 && ropeGlobal % ropeLocal != 0) ropeLocal--;
+        WorkerGrid ropeWorker = WorkerGridFactory.genericWorker(ropeGlobal, ropeLocal);
+
+        int attnLocal = Math.min(nEmbdHead, 128);
+        WorkerGrid attnWorker = WorkerGridFactory.genericWorker(batchSize * nHeads * attnLocal, attnLocal);
+
+        WorkerGrid mmaQkvWorker    = mmaGrid(paddedBatch, qDim + 2 * kvDim);
+        WorkerGrid mmaDimWorker    = mmaGrid(paddedBatch, dim);
+        WorkerGrid mmaGateUpWorker = mmaGrid(paddedBatch, 2 * hidDim);
+
+        WorkerGrid ewDimWorker = elementwiseGrid(batchSize * dim);
+        WorkerGrid ewHidWorker = elementwiseGrid(batchSize * hidDim);
+
+        for (int i = 0; i < config.numberOfLayers(); i++) {
+            String p = "batchDecodeLayer_" + i + ".";
+            scheduler.addWorkerGrid(p + "batch_attn_rms",       rmsWorker);
+            scheduler.addWorkerGrid(p + "batch_attn_rms_apply", rmsApplyWorker);
+            scheduler.addWorkerGrid(p + "qkvProj",              mmaQkvWorker);
+            scheduler.addWorkerGrid(p + "batch_qk_rmsnorm",     qkRmsNormWorker);
+            scheduler.addWorkerGrid(p + "batch_rope_kv",        ropeWorker);
+            scheduler.addWorkerGrid(p + "batch_attention",      attnWorker);
+            scheduler.addWorkerGrid(p + "woProj",               mmaDimWorker);
+            scheduler.addWorkerGrid(p + "batch_ffn_rms",        rmsWorker);
+            scheduler.addWorkerGrid(p + "batch_ffn_rms_apply",  ffnRmsApplyWorker);
+            scheduler.addWorkerGrid(p + "gateUpProj",           mmaGateUpWorker);
+            scheduler.addWorkerGrid(p + "swiglu",               ewHidWorker);
+            scheduler.addWorkerGrid(p + "w2Proj",               mmaDimWorker);
+            scheduler.addWorkerGrid(p + "w2Resid",              ewDimWorker);
+        }
+    }
+
+    public List<ImmutableTaskGraph> getLayerImmutableTaskGraphs() { return layerITGs; }
+    public String getLastLayerTaskGraphID()                        { return lastLayerTaskGraphID; }
+    public KernelContext getContext()                              { return context; }
+}


### PR DESCRIPTION
## Static batched decode — B independent LLaMA sequences per step

Decode **B independent sequences at once**, one token per step, each attending its
**own** KV cache. Turns the bandwidth-bound single-token matvecs of decode into
compute-bound tensor-core GEMMs (one weight read amortized across B tokens), so
aggregate throughput scales ~linearly with B until the 128-row MMA tile fills.

**41× aggregate throughput** vs single-stream decode on an RTX 4090 (Llama-3.2-1B
FP16), output verified coherent + bit-exact against the single-stream greedy reference.

Full write-up in [`BATCHED_DECODE.md`](BATCHED_DECODE.md).

### Why it wins
Single-token decode is memory-bound: each projection reads the whole weight matrix to
make one output vector (intensity ~1). Batch B tokens sharing the weights → each weight
row is read **once** and applied to **all B** → intensity ~B, a GEMM. Past B≈16 the
projections go compute-bound and the tensor cores engage. Attention doesn't batch this
way (per-sequence KV) but is a small fraction of decode FLOPs.

```
             single-token decode              static batched decode (B)
  weight W    read once  ─┐                     read once ─┐
  token x0    ───────────┼─> y0                 ──────────┼─> y0
  token x1    (read W again next step)          ──────────┼─> y1   one GEMM,
  token x2    (read W again) ...                ──────────┼─> y2   W read once
  intensity ~1 (HBM-bound)                      intensity ~B (compute-bound)
```

### Design

One step routine serves **both** phases. Prompt tokens are fed with logits discarded —
fills every slot's KV region with the *same* RoPE the decode step uses (no prefill/decode
mismatch). Then generated tokens feed back.

```
 embXBatch(FP16 B×dim)
      │  [0] prefillActivation      FP16 → FP32  wrapXBatch
      ▼
 ┌──────────  [1..N] batchDecodeLayer_i  (12 tasks, all GEMMs on MMA) ──────────┐
 │ batch_attn_rms → rms_apply → qkvProj(MMA) → batch_rope_kv* → batch_attention*│
 │ → woProj(MMA) → batch_ffn_rms → rms_apply → gateUpProj(MMA) → swiglu         │
 │ → w2Proj(MMA) → w2Resid            (*) only decode-specific kernels           │
 └─────────────────────────────────────────────────────────────────────────────┘
      │  wrapXBatch (B×dim, persists to next layer)
      ▼
 [N+1] batchLogits    final RMS → gemmMMA over vocab(128256) → logitsBatch (B×vocab)
```

The 12-task layer is **identical** to the existing batched-prefill MMA layer
(`LlamaFP16LayersBatchPrefillMMA`). Only two kernels change, and only in KV addressing:

| kernel | prefill (one sequence) | decode (B sequences) |
|--------|------------------------|----------------------|
| RoPE + KV write | `batchedRopeWithKVCachePacked` — `pos=start+b`, shared cache | `batchedDecodeRopeWithKVCachePacked` — `pos=seqPositions[b]`, per-slot base |
| flash attention | `batchedFlashAttentionFP16Out` — shared causal KV | `batchedDecodeAttentionFP16Out` — own KV region per slot |

RoPE math, online-softmax flash attention, register-partitioned P·V — all untouched; the
forks only change the KV index.

**Qwen3** reuses the pattern (`Qwen3FP16LayersBatchDecodeMMA`): keeps the per-head Q/K
RMS-norm task, swaps in split-half `batchedDecodeRopeWithKVCacheQwen3Packed` + the same
per-slot flash kernel (parameterized by qDim/nEmbdHead/gqa). Engine dispatches on model
type; embeddings + batched-logits GEMM are model-agnostic. KV cache is B-sized (`batchIdx` stride =
`numLayers·ctx·kvDim`), engine-owned so `ctx` can be capped for VRAM.

```
 keyCacheBatch [ slot0 | slot1 | … | slotB-1 ]   size = B·numLayers·ctx·kvDim
                  └ [ layer0 | layer1 | … ] └ [ pos0 | pos1 | … ] written at seqPositions[slot]
```

### Correctness
Greedy + B copies of one prompt → **all B streams bit-exact identical AND equal to the
single-stream greedy reference** (each slot reproduces the reference independently):
```
[verify] mode=greedy: all 128 streams identical (== single-stream greedy ref): true
```
Temperature + per-slot RNG → **B distinct, individually coherent** continuations (real
concurrent requests, not replication):
```
[verify] mode=sample temp=0.70: 128/128 streams distinct (independent per-slot KV)
```

### Performance (RTX 4090, Llama-3.2-1B FP16, ctx=512, 64 steps, CUDA graphs, steady-state)

| config | aggregate tok/s | vs single-stream | per-step |
|-------:|----------------:|-----------------:|---------:|
| single-stream (stock decode) | 101 | 1.0× | — |
| batched B=32  | 1085 | 10.7× | 29.5 ms |
| batched B=64  | 2167 | 21.5× | 29.5 ms |
| batched B=128 | **4175** | **41.3×** | 30.7 ms |

Across models (largest B that fits 24 GB; deeper/wider → higher per-step):

| model | layers·dim·vocab | single-stream | B | aggregate | speedup |
|-------|------------------|--------------:|:-:|----------:|--------:|
| Llama-3.2-1B | 16·2048·128256 | 101 | 128 | 4175 | 41× |
| Qwen3-1.7B   | 28·2048·151936 |  48 |  64 | 1433 | 30× |
| Qwen3-4B     | 36·2560·151936 |  39 |  32 |  405 | 10× |

All bit-exact vs single-stream greedy + coherent.

Per-step is ~flat (29–31 ms) from B=8 to B=128: every step runs at `paddedBatch=128`
(MMA tile is 128 rows) and the logits GEMM spans the full vocab regardless of B. So
aggregate scales ~linearly to B=128 (no pad waste) — **B=128 is the efficient operating
point**. Residual cost is real GEMM compute (full-vocab logits ~33 GFLOP + 16 layer
projections at 128 rows), not launch overhead — hence CUDA graphs help only ~6%.

### Reproduce

**TornadoVM:** needs the **CUDA backend** + MMA `KernelContext`
(`mmaFragment`/`mmaLoadA`/`mmaMultiply`, `HalfFloatArray`) — the same TornadoVM this
`feat/mma_cuda` branch already requires. Tested against **TornadoVM 5.0.1-jdk21-dev**,
CUDA backend, **JDK 21** (`make BACKEND=cuda`). All numbers here are from the CUDA backend.

**Build:** `mvn -Pjdk21 -Dtornadovm.base.version=5.0.1 -Djdk.version.suffix=-jdk21-dev clean package -DskipTests`

**Run** (`-Dllama.prefillBatchSize` MUST equal `-Dbatch.decode.B`; take
`llama-tornado --show-command`, swap main class, prepend flags):
```
-Dllama.prefillBatchSize=128 -Dbatch.decode.B=128 -Dbatch.decode.ctx=512 \
-Dbatch.decode.n=64 -Dbatch.decode.temp=0.0 -Dbatch.decode.cudaGraphs=true \
org.beehive.gpullama3.bench.BatchedDecodeEngine -m <llama-3.2-1b-fp16.gguf> -p "…" --instruct
```

Two micro-benchmarks isolate the regimes: `BatchedProjectionBench` (compute-bound
projection crossover, ~20×) and `BatchedDecodeAttentionBench` (memory-bound per-slot
attention, ~2×, bit-exact vs CPU ref).

### Scope
Additive — no existing path touched (new decode layer graph + 2 kernels + engine/benches).
FP16 LLaMA + Qwen3; same-length prompts (static). Qwen3-8B is garbage in the *stock* decode path on this build (not this feature). Ragged / continuous batching is the
follow-up — per-slot `seqPositions` + per-slot KV base already allow per-slot positions.

---

## Update: continuous batching + PagedAttention (vLLM-style)

**Continuous (iteration-level) batching** (`-Dbatch.decode.continuous=true`): each slot is
independently prefilling or decoding; a slot that hits stop/max is evicted and immediately
refilled from a pending queue — new requests join a partly-decoded batch mid-flight. Zero
kernel changes (the per-step forward already feeds one token per slot at its own
`seqPositions[b]`). Same 512-request workload (Llama-1B, B=128, max-gen∈[8,64], greedy):

| scheduling | steps | gen tok/s | req/s | slot utilization |
|------------|------:|----------:|------:|-----------------:|
| static wave | 336 | 1645 | 46.9 | 66.4% |
| **continuous** | **272** | **1972** | **56.2** | **82.2%** |

+20% throughput / +24% relative utilization; grows with length variance.

**PagedAttention** (`-Dbatch.decode.paged=true`, LLaMA): KV in a shared pool of fixed-size
blocks + per-slot block table; the two decode KV kernels index `blockTable[b][pos/blockSize]`.
Pool sized to actual concurrent demand, not `B·ctx`:

| KV cache | pool | peak used | throughput |
|----------|-----:|----------:|-----------:|
| contiguous | 4096 MB | — | 1972 tok/s |
| paged | **384 MB** | 372 blk (97%) | 1939 tok/s |

**~10.7× less KV memory** at ~1% overhead, still bit-exact. Undersizing the pool throws a
clear `KV block pool exhausted` (where admission control takes over). Prerequisite for
prefix caching. Details in `BATCHED_DECODE.md`.

---

## Update: prefix caching + Qwen3 paging

**Prefix caching** (`-Dbatch.decode.prefixCache=true`, needs paging): a shared prompt prefix
(system prompt / preamble) is prefilled **once** into pinned blocks; every request points its
block-table prefix rows at them and starts decoding at `pos = sharedPrefixLen`, skipping the
prefix's prefill. The attention kernel walks the block table, so it reads shared-then-private
blocks with **no kernel change**. Same 512-request continuous+paged workload, 48-tok shared
prompt (Llama-1B, B=128):

| | steps | gen tok/s | req/s | prefill tokens |
|--|------:|----------:|------:|---------------:|
| no prefix cache | 419 | 1307 | 37.2 | 28672 |
| **prefix cache** | **211** | **2422** | **69.0** | 4096 (**85.7% saved**) |

~2× fewer steps, **+85% throughput**; bit-exact.

**Qwen3** now runs the full stack (batched decode → continuous → paging → prefix caching) —
adds a split-half paged RoPE kernel; the paged flash kernel is shared (`qDim==nHeads·nEmbdHead`).
Qwen3-1.7B, 256-request continuous+paged, 48-tok shared prompt:

| Qwen3-1.7B | steps | gen tok/s | req/s | peak KV blocks |
|--|------:|----------:|------:|---------------:|
| paged, no prefix | 405 | 465 | 13.6 | 296 |
| **paged + prefix** | **193** | **949** | **27.7** | **151** |

**+104% throughput**; prefix sharing also halves peak KV blocks. All bit-exact.

vLLM-style feature set now on both LLaMA and Qwen3: continuous batching + PagedAttention +
prefix caching. Details + reproduction in `BATCHED_DECODE.md`.

---

## How to test — exact prompts and flags

**Launch.** The engine is a `main` on the standard TornadoVM module path. Easiest: capture the
JVM command from the normal runner, swap the main class to the engine, and prepend the `-D`
flags:

```bash
# 1) get the base JVM command for your model
python3 llama-tornado --gpu --cuda --model <model.gguf> --prompt x --instruct --show-command > cmd.txt

# 2) take the java line, replace the main class + prepend engine flags, set the prompt
BASE=$(grep 'bin/java' cmd.txt)
echo "$BASE" \
  | sed "s#org.beehive.gpullama3.LlamaApp#<ENGINE_FLAGS> org.beehive.gpullama3.bench.BatchedDecodeEngine#" \
  | sed 's#-p x --instruct#-p "<PROMPT>" --instruct#' | bash
```

`-Dllama.prefillBatchSize` **must equal** `-Dbatch.decode.B` (it sizes the batch buffers).
Larger models need more device memory — add `-Dtornado.device.memory=20GB` to `<ENGINE_FLAGS>`.

**Prompts used** (verbatim):

- `P_SHORT` = `Tell me a short story about a robot learning to paint.`
- `P_LONG` (48-token shared prefix) = `You are a helpful and knowledgeable assistant. Please write a detailed, vivid and engaging short story about a small curious robot named Zeta who lives in an old cluttered workshop and slowly learns the delicate art of painting with oil colors.`
- `P_QA` = `What is the capital of France?`

**Exact `<ENGINE_FLAGS>` per result** (model, prompt):

| result | model | prompt | flags |
|--------|-------|--------|-------|
| static B=128, 41× | llama-3.2-1b-fp16 | P_SHORT | `-Dllama.prefillBatchSize=128 -Dbatch.decode.B=128 -Dbatch.decode.ctx=512 -Dbatch.decode.n=64` |
| divergent streams | llama-3.2-1b-fp16 | P_SHORT | `…B=128 … -Dbatch.decode.temp=0.7` |
| continuous vs static-wave | llama-3.2-1b-fp16 | P_SHORT | `…B=128 … -Dbatch.decode.continuous=true -Dbatch.decode.requests=512 -Dbatch.decode.minN=8 -Dbatch.decode.refill=true`  (baseline: `refill=false`) |
| paged, 10.7× less KV | llama-3.2-1b-fp16 | P_SHORT | `…continuous=true -Dbatch.decode.paged=true -Dbatch.decode.blocks=384 -Dbatch.decode.requests=512 -Dbatch.decode.minN=8` |
| prefix cache, +85% | llama-3.2-1b-fp16 | P_LONG | `…continuous=true -Dbatch.decode.paged=true -Dbatch.decode.blocks=1024 -Dbatch.decode.prefixCache=true -Dbatch.decode.requests=512 -Dbatch.decode.minN=8`  (off: `prefixCache=false`) |
| Qwen3 paged + prefix, +104% | Qwen3-1.7B-f16 | P_LONG | `-Dtornado.device.memory=20GB -Dllama.prefillBatchSize=64 -Dbatch.decode.B=64 -Dbatch.decode.ctx=512 -Dbatch.decode.n=64 -Dbatch.decode.continuous=true -Dbatch.decode.paged=true -Dbatch.decode.blocks=768 -Dbatch.decode.prefixCache=true -Dbatch.decode.requests=256 -Dbatch.decode.minN=8`  (off: `prefixCache=false`) |
| Qwen3-4B batched | Qwen3-4B-f16 | P_QA | `-Dtornado.device.memory=20GB -Dllama.prefillBatchSize=32 -Dbatch.decode.B=32 -Dbatch.decode.ctx=512 -Dbatch.decode.n=48` |

**Single-stream baselines** (stock decode, for the speedup ratios): normal runner with CUDA
graphs, e.g. `JAVA_TOOL_OPTIONS=-Dllama.cudaGraphs=true python3 llama-tornado --gpu --cuda
--model <m.gguf> --prompt "<P_SHORT>" --instruct -n 64` → reads `achieved tok/s`.

**All flags** (defaults in parens): `batch.decode.B`, `.ctx` (512), `.n` (64), `.temp` (0=greedy),
`.cudaGraphs` (true), `.continuous` (false), `.refill` (true), `.requests` (4·B), `.minN` (n/2),
`.paged` (false), `.blockSize` (16), `.blocks` (B·ctx/blockSize), `.prefixCache` (false).
Each run prints `[verify] … : true` (correctness) and `[perf] …` (throughput).


---

### Qwen3 — verified fresh (multi-request serving)

Re-ran the full stack on **Qwen3 FP16** (RTX 4090, TornadoVM 5.0.1-jdk21-dev, JDK 21).
Every configuration is bit-exact vs the single-stream greedy reference (static) or
mutually prefix-consistent (continuous):

| model | mode | throughput |
|-------|------|-----------:|
| Qwen3-1.7B | static B=8 / 16 / 32 | 198 / 402 / **801** tok/s (32×) |
| Qwen3-1.7B | continuous B=16, R=128, paged+prefix | 301 tok/s · 6.2 req/s · 95.8% util |
| Qwen3-4B | static B=16 / 32 | 217 / **424** tok/s (32×) |

Per-stream tok/s stays flat as B grows (batching is free until the 128-row MMA tile fills).

**Copy-paste reproduce** (Qwen3 static + continuous serving) added to
[`BATCHED_DECODE.md` → Reproduce → Qwen3 quick start](BATCHED_DECODE.md#reproduce) and as
step-by-step javadoc on `BatchedDecodeEngine`.