### PR TITLE
[build] Add JDK 22–27+ support via consolidated jdk22plus profile

### DIFF
--- a/.claude/skills/build-n-run-engine/SKILL.md
+++ b/.claude/skills/build-n-run-engine/SKILL.md
@@ -20,7 +20,7 @@ Build GPULlama3.java (this repo) with Maven, skipping tests for speed.
 
 ## Prerequisites
 
-- `JAVA_HOME` set to JDK 21 or 25 (`java -version`)
+- `JAVA_HOME` set to JDK 21, 25, or 27 (`java -version`)
 - `TORNADOVM_HOME` set and `tornado --devices` succeeds — if not, run the `build-tornado` skill first
 - `~/TornadoVM/setvars.sh` sourced in **this** shell (env vars don't persist across shells/tool calls)
 
@@ -51,7 +51,7 @@ git checkout <branch> && git pull
 mvn clean install -DskipTests
 ```
 
-For JDK 25 instead of the default JDK 21, ensure `JAVA_HOME` points at JDK 25 before running `make` — the pom auto-activates the `jdk25` profile from the detected JDK version, there is no separate `BACKEND=`-style flag.
+For JDK 25 or JDK 27 instead of the default JDK 21, ensure `JAVA_HOME` points at that JDK before building — the pom auto-activates the matching `jdk25`/`jdk27` profile from the detected JDK version, there is no separate `BACKEND=`-style flag. The `jdk27` profile pins `tornadovm.version` to the locally-installed `5.2.1-jdk27-dev` artifact (no `5.0.0-jdk27` release exists) and compiles without `--enable-preview` (unnecessary at release 27; only `--add-modules jdk.incubator.vector` is needed).
 
 ### Step 5: Verify
 

--- a/.claude/skills/build-n-run-engine/SKILL.md
+++ b/.claude/skills/build-n-run-engine/SKILL.md
@@ -20,7 +20,7 @@ Build GPULlama3.java (this repo) with Maven, skipping tests for speed.
 
 ## Prerequisites
 
-- `JAVA_HOME` set to JDK 21, 25, or 27 (`java -version`)
+- `JAVA_HOME` set to JDK 21, or JDK 22+ (22, 23, 24, 25, 26, 27, ...) (`java -version`)
 - `TORNADOVM_HOME` set and `tornado --devices` succeeds — if not, run the `build-tornado` skill first
 - `~/TornadoVM/setvars.sh` sourced in **this** shell (env vars don't persist across shells/tool calls)
 
@@ -51,7 +51,7 @@ git checkout <branch> && git pull
 mvn clean install -DskipTests
 ```
 
-For JDK 25 or JDK 27 instead of the default JDK 21, ensure `JAVA_HOME` points at that JDK before building — the pom auto-activates the matching `jdk25`/`jdk27` profile from the detected JDK version, there is no separate `BACKEND=`-style flag. The `jdk27` profile pins `tornadovm.version` to the locally-installed `5.2.1-jdk27-dev` artifact (no `5.0.0-jdk27` release exists) and compiles without `--enable-preview` (unnecessary at release 27; only `--add-modules jdk.incubator.vector` is needed).
+For JDK 22 and newer (22, 23, 24, 25, 26, 27, ...) instead of the default JDK 21, ensure `JAVA_HOME` points at that JDK before building — the pom auto-activates the `jdk22plus` profile (activation range `[22,)`) from the detected JDK version, there is no separate `BACKEND=`-style flag. `jdk22plus` replaced the former per-version `jdk25`/`jdk26`/`jdk27` profiles with one consolidated profile that pins `tornadovm.version` to the locally-installed `5.2.1-jdk22plus-dev` artifact and compiles without `--enable-preview` (unnecessary from release 22 onward; only `--add-modules jdk.incubator.vector` is needed).
 
 ### Step 5: Verify
 

--- a/.claude/skills/build-tornado/SKILL.md
+++ b/.claude/skills/build-tornado/SKILL.md
@@ -18,8 +18,13 @@ Build TornadoVM from source. Available backends: `opencl` (default), `ptx`, `spi
 
 ## Prerequisites
 
-- JAVA_HOME is set to jdk 21 or 25
+- JAVA_HOME is set to jdk 21, 25, or 27
 - `nvidia-smi` succeeds (GPUs visible)
+
+Note: JDK 27 removed JVMCI entirely (openjdk/jdk#30834). TornadoVM's `jdk27` pom profile
+vendors a same-named `jdk.internal.vm.ci` application module to compensate — see the
+`jdk27-jvmci-removal` branch. `bin/compile --jdk jdk27` (and `make`) auto-detect this from
+`JAVA_HOME`.
 
 ## Instructions
 

--- a/.claude/skills/build-tornado/SKILL.md
+++ b/.claude/skills/build-tornado/SKILL.md
@@ -18,7 +18,7 @@ Build TornadoVM from source. Available backends: `opencl` (default), `ptx`, `spi
 
 ## Prerequisites
 
-- JAVA_HOME is set to jdk 21, 25, or 27
+- JAVA_HOME is set to jdk 21, or 22+ (22, 23, 24, 25, 26, 27, ...)
 - `nvidia-smi` succeeds (GPUs visible)
 
 Note: JDK 27 removed JVMCI entirely (openjdk/jdk#30834). TornadoVM's `jdk27` pom profile

--- a/.github/workflows/deploy-maven-central.yml
+++ b/.github/workflows/deploy-maven-central.yml
@@ -33,6 +33,14 @@ jobs:
             java_version: 21.0.2-open
           - name: jdk25
             java_version: 25.0.2-open
+          # jdk26/jdk27 intentionally held back: TornadoVM has not yet published GA
+          # 5.2.1-jdk26/-jdk27 to Maven Central (only the "-dev" line exists today), so
+          # a deploy attempt would just fail on dependency resolution. Add matrix entries
+          #   - name: jdk26
+          #     java_version: 26.0.2-open
+          #   - name: jdk27
+          #     java_version: 27.ea.31-open   # no GA JDK 27 build exists yet either
+          # back once TornadoVM's 5.2.1 GA release is confirmed published.
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-maven-central.yml
+++ b/.github/workflows/deploy-maven-central.yml
@@ -31,16 +31,17 @@ jobs:
         jdk:
           - name: jdk21
             java_version: 21.0.2-open
-          - name: jdk25
+          - name: jdk22plus
             java_version: 25.0.2-open
-          # jdk26/jdk27 intentionally held back: TornadoVM has not yet published GA
-          # 5.2.1-jdk26/-jdk27 to Maven Central (only the "-dev" line exists today), so
-          # a deploy attempt would just fail on dependency resolution. Add matrix entries
-          #   - name: jdk26
-          #     java_version: 26.0.2-open
-          #   - name: jdk27
-          #     java_version: 27.ea.31-open   # no GA JDK 27 build exists yet either
-          # back once TornadoVM's 5.2.1 GA release is confirmed published.
+          # A single jdk22plus matrix entry now covers JDK 22 through 27+: the pom's
+          # jdk22plus profile (which replaced the former separate jdk25/jdk26/jdk27
+          # profiles) publishes one gpu-llama3:*-jdk22plus artifact that every JDK in
+          # that range resolves, mirroring TornadoVM's own consolidated jdk22plus SDK.
+          # Building it on 25.0.2-open is just this job's pick of JDK within the range,
+          # not a jdk25-specific artifact - no separate jdk26/jdk27 entries are needed.
+          # TornadoVM has not yet published GA 5.2.1-jdk22plus to Maven Central (only
+          # the "-dev" line exists today), so this entry will fail dependency resolution
+          # until that GA release lands - same caveat the old jdk26/jdk27 note carried.
 
     steps:
       - name: Checkout code

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -92,7 +92,7 @@ jobs:
 
           SNIPPET_FILE="${{ runner.temp }}/dependency_snippet.md"
           cat > "$SNIPPET_FILE" <<EOF
-          **JDK 21** (\`jdk21\` profile, auto-activates for JDK \`[21,25)\`):
+          **JDK 21** (\`jdk21\` profile, auto-activates for JDK \`[21,22)\`):
           \`\`\`xml
           <dependency>
               <groupId>io.github.beehive-lab</groupId>
@@ -101,12 +101,12 @@ jobs:
           </dependency>
           \`\`\`
 
-          **JDK 25** (\`jdk25\` profile, auto-activates for JDK \`[25.0.2,)\`):
+          **JDK 22+** (\`jdk22plus\` profile, auto-activates for JDK \`[22,)\` — covers 22, 23, 24, 25, 26, 27 and later):
           \`\`\`xml
           <dependency>
               <groupId>io.github.beehive-lab</groupId>
               <artifactId>gpu-llama3</artifactId>
-              <version>${VERSION}-jdk25</version>
+              <version>${VERSION}-jdk22plus</version>
           </dependency>
           \`\`\`
 
@@ -117,9 +117,9 @@ jobs:
           implementation 'io.github.beehive-lab:gpu-llama3:${VERSION}-jdk21'
           \`\`\`
 
-          **JDK 25**:
+          **JDK 22+**:
           \`\`\`groovy
-          implementation 'io.github.beehive-lab:gpu-llama3:${VERSION}-jdk25'
+          implementation 'io.github.beehive-lab:gpu-llama3:${VERSION}-jdk22plus'
           \`\`\`
           EOF
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build JDK21](https://github.com/beehive-lab/GPULlama3.java/actions/workflows/build-and-run.yml/badge.svg)](https://github.com/beehive-lab/GPULlama3.java/actions/workflows/build-and-run.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.beehive-lab/gpu-llama3?&logo=apache-maven&color=blue)](https://central.sonatype.com/artifact/io.github.beehive-lab/gpu-llama3)
 ![Java 21](https://img.shields.io/badge/java-21-blue?logo=openjdk)
-![Java 25](https://img.shields.io/badge/java-25-yellow?logo=openjdk)
+![Java 22+](https://img.shields.io/badge/java-22%2B-yellow?logo=openjdk)
 [![LangChain4j](https://img.shields.io/badge/LangChain4j-1.7.1+-purple?&logo=link&logoColor=white)](https://docs.langchain4j.dev/)
 ![NVIDIA](https://img.shields.io/badge/CUDA%20%7C%20PTX-supported-76B900?logo=nvidia)
 ![OpenCL](https://img.shields.io/badge/OpenCL-supported-blue?logo=khronos)
@@ -94,7 +94,7 @@ GPULlama3ChatModel model = GPULlama3ChatModel.builder()
 ### 📦 Maven
 
 <!-- DEPENDENCY-SNIPPETS:START -->
-**JDK 21** (`jdk21` profile, auto-activates for JDK `[21,25)`):
+**JDK 21** (`jdk21` profile, auto-activates for JDK `[21,22)`):
 ```xml
 <dependency>
     <groupId>io.github.beehive-lab</groupId>
@@ -103,12 +103,12 @@ GPULlama3ChatModel model = GPULlama3ChatModel.builder()
 </dependency>
 ```
 
-**JDK 25** (`jdk25` profile, auto-activates for JDK `[25.0.2,)`):
+**JDK 22+** (`jdk22plus` profile, auto-activates for JDK `[22,)` — covers 22, 23, 24, 25, 26, 27 and later):
 ```xml
 <dependency>
     <groupId>io.github.beehive-lab</groupId>
     <artifactId>gpu-llama3</artifactId>
-    <version>1.0.0-jdk25</version>
+    <version>1.0.0-jdk22plus</version>
 </dependency>
 ```
 
@@ -119,9 +119,9 @@ GPULlama3ChatModel model = GPULlama3ChatModel.builder()
 implementation 'io.github.beehive-lab:gpu-llama3:1.0.0-jdk21'
 ```
 
-**JDK 25**:
+**JDK 22+**:
 ```groovy
-implementation 'io.github.beehive-lab:gpu-llama3:1.0.0-jdk25'
+implementation 'io.github.beehive-lab:gpu-llama3:1.0.0-jdk22plus'
 ```
 <!-- DEPENDENCY-SNIPPETS:END -->
 
@@ -137,7 +137,7 @@ implementation 'io.github.beehive-lab:gpu-llama3:1.0.0-jdk25'
 
 ### Prerequisites
 
-- **Java 21** — required for the Vector API & TornadoVM (Java 25 supported via the `-jdk25` artifact / `llamaTornado` script).
+- **Java 21+** — required for the Vector API & TornadoVM. JDK 21 uses the `-jdk21` artifact; JDK 22 and newer (22, 23, 24, 25, 26, 27, ...) uses the `-jdk22plus` artifact / `llamaTornado` script.
 - **[TornadoVM](https://github.com/beehive-lab/TornadoVM)** with an OpenCL, PTX, CUDA, or Metal backend. `llama-tornado`/`llamaTornado` auto-detect whichever backend your installed SDK was built with.
 - **GCC/G++ 13+** — to build TornadoVM's native components.
 

--- a/llama-tornado
+++ b/llama-tornado
@@ -10,6 +10,7 @@ The backend is auto-detected from the installed TornadoVM SDK
 import argparse
 import glob
 import os
+import re
 import subprocess
 import sys
 import time
@@ -80,6 +81,21 @@ class LlamaRunner:
             print("Note: check set_path in root dir -> source set_path")
             sys.exit(1)
 
+        self.java_version = self._detect_java_version()
+
+    def _detect_java_version(self) -> Optional[int]:
+        """Parse the JDK feature/major version out of `$JAVA_HOME/bin/java -version`,
+        e.g. 'openjdk version "21.0.2" ...' -> 21, 'openjdk version "27-ea" ...' -> 27."""
+        try:
+            output = subprocess.run(
+                [f"{self.java_home}/bin/java", "-version"],
+                capture_output=True, text=True, check=True,
+            ).stderr
+        except (OSError, subprocess.CalledProcessError):
+            return None
+        match = re.search(r'version "(\d+)', output)
+        return int(match.group(1)) if match else None
+
     def _validate_paths(self):
         """Validate that required paths exist."""
         paths_to_check = {
@@ -134,19 +150,49 @@ class LlamaRunner:
 
     def _build_base_command(self, args: argparse.Namespace) -> List[str]:
         """Build the base Java command with JVM options."""
+        # JDK 27+ removed the platform jdk.internal.vm.ci module entirely; TornadoVM ships a
+        # vendored same-named module for that case, which must go on the module-path (mirrors
+        # tornado.py's self.jvmci_absent). On JDK <=26 the platform module is still present and
+        # a same-named module on the module-path would cause a "two versions of module" error,
+        # so it's deliberately left off here -- see the --patch-module handling below instead.
+        jvmci_absent = self.java_version is not None and self.java_version >= 27
+        module_path_entries = [".", f"{self.tornado_sdk}/share/java/tornado"]
+        if jvmci_absent:
+            module_path_entries.append(f"{self.tornado_sdk}/share/java/jvmci")
+
         cmd = [
             f"{self.java_home}/bin/java",
             "-server",
             "-XX:+UnlockExperimentalVMOptions",
-            "-XX:+EnableJVMCI",
-            f"-Xms{args.heap_min}",
-            f"-Xmx{args.heap_max}",
-            "--enable-preview",
-            f"-Djava.library.path={self.tornado_sdk}/lib",
-            "-Djdk.module.showModuleResolution=false",
-            "--module-path",
-            self.module_path_colon_sep([".", f"{self.tornado_sdk}/share/java/tornado"]),
         ]
+        if jvmci_absent:
+            # JDK 27+ removed JVMCI entirely (openjdk/jdk#30834): -XX:+EnableJVMCI is now an
+            # unrecognized (fatal) VM option, and Panama/FFM is final so --enable-preview is
+            # unnecessary. Mirrors tornado.py's __JAVA_BASE_OPTIONS_NO_JVMCI__: set the saved
+            # property the vendored jdk.vm.ci.services.Services.checkJVMCIEnabled() reads
+            # (HotSpot's own +EnableJVMCI bookkeeping no longer exists to set it), and export the
+            # java.base internals the vendored jdk.internal.vm.ci module needs.
+            cmd.extend(
+                [
+                    "-Djdk.internal.vm.ci.enabled=true",
+                    "--add-exports", "java.base/jdk.internal.misc=jdk.internal.vm.ci",
+                    "--add-exports", "java.base/jdk.internal.vm=jdk.internal.vm.ci",
+                    "--add-exports", "java.base/jdk.internal.vm.annotation=jdk.internal.vm.ci",
+                    "--add-exports", "java.base/jdk.internal.reflect=jdk.internal.vm.ci",
+                ]
+            )
+        else:
+            cmd.extend(["-XX:+EnableJVMCI", "--enable-preview"])
+        cmd.extend(
+            [
+                f"-Xms{args.heap_min}",
+                f"-Xmx{args.heap_max}",
+                f"-Djava.library.path={self.tornado_sdk}/lib",
+                "-Djdk.module.showModuleResolution=false",
+                "--module-path",
+                self.module_path_colon_sep(module_path_entries),
+            ]
+        )
 
         # TornadoVM configuration
         tornado_config = [
@@ -265,6 +311,21 @@ class LlamaRunner:
             module_config.append(f"@{self.tornado_sdk}/etc/exportLists/{BACKEND_EXPORTS_FILE[backend]}")
             add_modules.append(BACKEND_MODULE_NAME[backend])
         module_config.extend(["--add-modules", ",".join(add_modules)])
+
+        # JDK 22-26 still ship jdk.internal.vm.ci, but its jdk.vm.ci.* interfaces have drifted
+        # from the JDK-21 shape the reflection providers were compiled against (e.g.
+        # jdk.vm.ci.code.Architecture's constructor). Overlay the frozen JDK-21 classes so the
+        # loaded jdk.vm.ci.* matches what was compiled -- mirrors tornado.py's jvmci_patched
+        # branch, which `tornado --printJavaFlags` applies but this script builds its command
+        # independently of, so it has to be replicated here too.
+        if self.java_version is not None and 22 <= self.java_version <= 26:
+            module_config.extend(
+                [
+                    "-Djdk.internal.vm.ci.enabled=true",
+                    "--patch-module",
+                    f"jdk.internal.vm.ci={self.tornado_sdk}/share/java/jvmci/jvmci-21.0.2.jar",
+                ]
+            )
 
         if getattr(args, "server", False):
             main_class = "org.beehive.gpullama3.server.OpenAIServer"

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
             <jdk.version.suffix>-jdk21</jdk.version.suffix>
             <!-- CUDA backend is only available after 5.0.0 TornadoVM version -->
             <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
+            <tornadovm.dev.suffix>-dev</tornadovm.dev.suffix>
             <!-- Compiler defaults (overridden by JDK profiles below) -->
             <maven.compiler.source>25</maven.compiler.source>
             <maven.compiler.target>25</maven.compiler.target>
@@ -204,8 +205,8 @@
                  Auto-activates for JDK 26.x builds.
                  Publishes: gpu-llama3:${revision}-jdk26
                  TornadoVM: pinned to the locally-built 5.2.1-jdk26-dev artifacts (no
-                 5.0.0-jdk26 release exists yet, so this does not follow the base+suffix
-                 composition the jdk21/jdk25 profiles use).
+                 5.0.0-jdk26 release exists yet, so tornadovm.base.version is overridden
+                 to 5.2.1 here and composed with tornadovm.dev.suffix below).
                  Vector API is still incubating in JDK 26; add-modules jdk.incubator.vector
                  is required for compilation.
             ─────────────────────────────────────────────────────────────────────── -->
@@ -216,7 +217,8 @@
                     <maven.compiler.source>26</maven.compiler.source>
                     <maven.compiler.target>26</maven.compiler.target>
                     <jdk.version.suffix>-jdk26</jdk.version.suffix>
-                    <tornadovm.version>5.2.1-jdk26-dev</tornadovm.version>
+                    <tornadovm.base.version>5.2.1</tornadovm.base.version>
+                    <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}${tornadovm.dev.suffix}</tornadovm.version>
                 </properties>
                 <build>
                     <plugins>
@@ -240,8 +242,8 @@
                  openjdk/jdk#30834 — see the matching jdk27 profile in TornadoVM's own pom).
                  Publishes: gpu-llama3:${revision}-jdk27
                  TornadoVM: pinned to the locally-built 5.2.1-jdk27-dev artifacts (no
-                 5.0.0-jdk27 release exists yet, so this does not follow the base+suffix
-                 composition the other profiles use).
+                 5.0.0-jdk27 release exists yet, so tornadovm.base.version is overridden
+                 to 5.2.1 here and composed with tornadovm.dev.suffix below).
                  No enable-preview: unlike the jdk21/jdk25 profiles, this project's sources
                  compile clean at release 27 with only add-modules jdk.incubator.vector,
                  so the base build's enable-preview arg is dropped via combine.self="override".
@@ -253,7 +255,8 @@
                     <maven.compiler.source>27</maven.compiler.source>
                     <maven.compiler.target>27</maven.compiler.target>
                     <jdk.version.suffix>-jdk27</jdk.version.suffix>
-                    <tornadovm.version>5.2.1-jdk27-dev</tornadovm.version>
+                    <tornadovm.base.version>5.2.1</tornadovm.base.version>
+                    <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}${tornadovm.dev.suffix}</tornadovm.version>
                 </properties>
                 <build>
                     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
             <jdk.version.suffix>-jdk21</jdk.version.suffix>
             <!-- CUDA backend is only available after 5.0.0 TornadoVM version -->
             <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
+            <!-- Composed into jdk26/jdk27's tornadovm.version below, since no GA TornadoVM
+                 release exists yet for those JDKs, only locally-built "-dev" artifacts.
+                 Cleared to empty in the release profile so published (Maven Central) POMs
+                 never depend on an unresolvable "-dev" coordinate; see that profile. -->
             <tornadovm.dev.suffix>-dev</tornadovm.dev.suffix>
             <!-- Compiler defaults (overridden by JDK profiles below) -->
             <maven.compiler.source>25</maven.compiler.source>
@@ -279,6 +283,12 @@
                 <properties>
                     <maven.javadoc.skip>false</maven.javadoc.skip>
                     <gpg.skip>false</gpg.skip>
+                    <!-- Overrides the "-dev" default (see top-level properties) so a real
+                         release never publishes a POM depending on an unpublished
+                         tornado-api/tornado-runtime:*-dev coordinate. Only takes effect once
+                         jdk26/jdk27 are added to deploy-maven-central.yml's matrix, and only
+                         once a GA TornadoVM release exists for those JDKs to point at instead. -->
+                    <tornadovm.dev.suffix></tornadovm.dev.suffix>
                 </properties>
                 <build>
                     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,41 @@
                 </build>
             </profile>
 
+            <!-- ─── JDK 26 ───────────────────────────────────────────────────────────
+                 Auto-activates for JDK 26.x builds.
+                 Publishes: gpu-llama3:${revision}-jdk26
+                 TornadoVM: pinned to the locally-built 5.2.1-jdk26-dev artifacts (no
+                 5.0.0-jdk26 release exists yet, so this does not follow the base+suffix
+                 composition the jdk21/jdk25 profiles use).
+                 Vector API is still incubating in JDK 26; add-modules jdk.incubator.vector
+                 is required for compilation.
+            ─────────────────────────────────────────────────────────────────────── -->
+            <profile>
+                <id>jdk26</id>
+                <activation><jdk>[26,27)</jdk></activation>
+                <properties>
+                    <maven.compiler.source>26</maven.compiler.source>
+                    <maven.compiler.target>26</maven.compiler.target>
+                    <jdk.version.suffix>-jdk26</jdk.version.suffix>
+                    <tornadovm.version>5.2.1-jdk26-dev</tornadovm.version>
+                </properties>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <!-- Appended to enable-preview already in main build -->
+                                <compilerArgs combine.children="append">
+                                    <arg>--add-modules</arg>
+                                    <arg>jdk.incubator.vector</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </profile>
+
             <!-- ─── JDK 27 ───────────────────────────────────────────────────────────
                  Auto-activates for JDK 27+ builds (JVMCI fully removed upstream,
                  openjdk/jdk#30834 — see the matching jdk27 profile in TornadoVM's own pom).

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
             ─────────────────────────────────────────────────────────────────────── -->
             <profile>
                 <id>jdk25</id>
-                <activation><jdk>[25.0.2,)</jdk></activation>
+                <activation><jdk>[25.0.2,26)</jdk></activation>
                 <properties>
                     <maven.compiler.source>25</maven.compiler.source>
                     <maven.compiler.target>25</maven.compiler.target>
@@ -191,6 +191,42 @@
                             <configuration>
                                 <!-- Appended to enable-preview already in main build -->
                                 <compilerArgs combine.children="append">
+                                    <arg>--add-modules</arg>
+                                    <arg>jdk.incubator.vector</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </profile>
+
+            <!-- ─── JDK 27 ───────────────────────────────────────────────────────────
+                 Auto-activates for JDK 27+ builds (JVMCI fully removed upstream,
+                 openjdk/jdk#30834 — see the matching jdk27 profile in TornadoVM's own pom).
+                 Publishes: gpu-llama3:${revision}-jdk27
+                 TornadoVM: pinned to the locally-built 5.2.1-jdk27-dev artifacts (no
+                 5.0.0-jdk27 release exists yet, so this does not follow the base+suffix
+                 composition the other profiles use).
+                 No enable-preview: unlike the jdk21/jdk25 profiles, this project's sources
+                 compile clean at release 27 with only add-modules jdk.incubator.vector,
+                 so the base build's enable-preview arg is dropped via combine.self="override".
+            ─────────────────────────────────────────────────────────────────────── -->
+            <profile>
+                <id>jdk27</id>
+                <activation><jdk>[27,)</jdk></activation>
+                <properties>
+                    <maven.compiler.source>27</maven.compiler.source>
+                    <maven.compiler.target>27</maven.compiler.target>
+                    <jdk.version.suffix>-jdk27</jdk.version.suffix>
+                    <tornadovm.version>5.2.1-jdk27-dev</tornadovm.version>
+                </properties>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration combine.self="override">
+                                <compilerArgs>
                                     <arg>--add-modules</arg>
                                     <arg>jdk.incubator.vector</arg>
                                 </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
             ─────────────────────────────────────────────────────────────────────── -->
             <profile>
                 <id>jdk21</id>
-                <activation><jdk>[21,25)</jdk></activation>
+                <activation><jdk>[21,22)</jdk></activation>
                 <properties>
                     <maven.compiler.source>21</maven.compiler.source>
                     <maven.compiler.target>21</maven.compiler.target>
@@ -178,93 +178,29 @@
                 </build>
             </profile>
 
-            <!-- ─── JDK 25 ───────────────────────────────────────────────────────────
-                 Auto-activates for JDK 25.0.2+ builds (minimum required version).
-                 Publishes: gpu-llama3:${revision}-jdk25
-                 TornadoVM: ${tornadovm.base.version}-jdk25${tornadovm.dev.suffix} - see the
-                 jdk21 profile above for why the dev suffix is composed in here too.
-                 Vector API is still incubating in JDK 25 (JEP 508 — 10th Incubator);
-                 add-modules jdk.incubator.vector is required for compilation.
+            <!-- ─── JDK 22+ ──────────────────────────────────────────────────────────
+                 Auto-activates for JDK 22 and newer. TornadoVM consolidated its old
+                 per-version jdk25/jdk26/jdk27 dev profiles into one "jdk22plus" SDK
+                 build that runs unchanged on 22, 23, ..., 27 and later, so one
+                 profile here (replacing the former jdk25/jdk26/jdk27 profiles) covers
+                 the whole open-ended range too.
+                 Publishes: gpu-llama3:${revision}-jdk22plus
+                 TornadoVM: ${tornadovm.base.version}-jdk22plus${tornadovm.dev.suffix}
+                 No enable-preview: FFM (the only preview API this project's JDK21 build
+                 needs it for) is final since JDK 22, and the former jdk27 profile already
+                 proved sources compile clean at release 27 with just add-modules
+                 jdk.incubator.vector - so the base build's enable-preview arg is dropped
+                 via combine.self="override", same as that profile did.
+                 Vector API remains incubating through at least JDK 27 (JEP 508); add-
+                 modules jdk.incubator.vector is required for compilation across the range.
             ─────────────────────────────────────────────────────────────────────── -->
             <profile>
-                <id>jdk25</id>
-                <activation><jdk>[25.0.2,26)</jdk></activation>
+                <id>jdk22plus</id>
+                <activation><jdk>[22,)</jdk></activation>
                 <properties>
-                    <maven.compiler.source>25</maven.compiler.source>
-                    <maven.compiler.target>25</maven.compiler.target>
-                    <jdk.version.suffix>-jdk25</jdk.version.suffix>
-                    <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}${tornadovm.dev.suffix}</tornadovm.version>
-                </properties>
-                <build>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <configuration>
-                                <!-- Appended to enable-preview already in main build -->
-                                <compilerArgs combine.children="append">
-                                    <arg>--add-modules</arg>
-                                    <arg>jdk.incubator.vector</arg>
-                                </compilerArgs>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </build>
-            </profile>
-
-            <!-- ─── JDK 26 ───────────────────────────────────────────────────────────
-                 Auto-activates for JDK 26.x builds.
-                 Publishes: gpu-llama3:${revision}-jdk26
-                 TornadoVM: ${tornadovm.base.version}-jdk26${tornadovm.dev.suffix} - inherits
-                 tornadovm.base.version from the top-level properties (no override needed here;
-                 no GA TornadoVM release for jdk26 exists below that version yet, only the
-                 locally-built "-dev" artifacts tornadovm.dev.suffix composes in by default).
-                 Vector API is still incubating in JDK 26; add-modules jdk.incubator.vector
-                 is required for compilation.
-            ─────────────────────────────────────────────────────────────────────── -->
-            <profile>
-                <id>jdk26</id>
-                <activation><jdk>[26,27)</jdk></activation>
-                <properties>
-                    <maven.compiler.source>26</maven.compiler.source>
-                    <maven.compiler.target>26</maven.compiler.target>
-                    <jdk.version.suffix>-jdk26</jdk.version.suffix>
-                    <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}${tornadovm.dev.suffix}</tornadovm.version>
-                </properties>
-                <build>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <configuration>
-                                <!-- Appended to enable-preview already in main build -->
-                                <compilerArgs combine.children="append">
-                                    <arg>--add-modules</arg>
-                                    <arg>jdk.incubator.vector</arg>
-                                </compilerArgs>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </build>
-            </profile>
-
-            <!-- ─── JDK 27 ───────────────────────────────────────────────────────────
-                 Auto-activates for JDK 27+ builds (JVMCI fully removed upstream,
-                 openjdk/jdk#30834 — see the matching jdk27 profile in TornadoVM's own pom).
-                 Publishes: gpu-llama3:${revision}-jdk27
-                 TornadoVM: ${tornadovm.base.version}-jdk27${tornadovm.dev.suffix} - inherits
-                 tornadovm.base.version from the top-level properties, same as jdk26 above.
-                 No enable-preview: unlike the jdk21/jdk25 profiles, this project's sources
-                 compile clean at release 27 with only add-modules jdk.incubator.vector,
-                 so the base build's enable-preview arg is dropped via combine.self="override".
-            ─────────────────────────────────────────────────────────────────────── -->
-            <profile>
-                <id>jdk27</id>
-                <activation><jdk>[27,)</jdk></activation>
-                <properties>
-                    <maven.compiler.source>27</maven.compiler.source>
-                    <maven.compiler.target>27</maven.compiler.target>
-                    <jdk.version.suffix>-jdk27</jdk.version.suffix>
+                    <maven.compiler.source>22</maven.compiler.source>
+                    <maven.compiler.target>22</maven.compiler.target>
+                    <jdk.version.suffix>-jdk22plus</jdk.version.suffix>
                     <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}${tornadovm.dev.suffix}</tornadovm.version>
                 </properties>
                 <build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,16 @@
         <properties>
             <!-- CI-friendly version: resolved by flatten-maven-plugin at build time -->
             <revision>1.0.0</revision>
-            <tornadovm.base.version>5.0.0</tornadovm.base.version>
+            <tornadovm.base.version>5.2.1</tornadovm.base.version>
             <jdk.version.suffix>-jdk21</jdk.version.suffix>
             <!-- CUDA backend is only available after 5.0.0 TornadoVM version -->
             <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
-            <!-- Composed into jdk26/jdk27's tornadovm.version below, since no GA TornadoVM
-                 release exists yet for those JDKs, only locally-built "-dev" artifacts.
-                 Cleared to empty in the release profile so published (Maven Central) POMs
-                 never depend on an unresolvable "-dev" coordinate; see that profile. -->
+            <!-- Composed into every jdk21/25/26/27 profile's tornadovm.version below. Defaults
+                 to "-dev" so day-to-day builds track a locally-built TornadoVM checkout at
+                 whatever tag tornadovm.base.version currently points at (bump that property
+                 alone to move to a newer TornadoVM tag). Cleared to empty in the release
+                 profile so published (Maven Central) POMs always depend on the plain GA
+                 coordinate instead of an unresolvable "-dev" one; see that profile. -->
             <tornadovm.dev.suffix>-dev</tornadovm.dev.suffix>
             <!-- Compiler defaults (overridden by JDK profiles below) -->
             <maven.compiler.source>25</maven.compiler.source>
@@ -143,7 +145,11 @@
             <!-- ─── JDK 21 ───────────────────────────────────────────────────────────
                  Auto-activates for JDK 21.x builds.
                  Publishes: gpu-llama3:${revision}  (no suffix)
-                 TornadoVM: ${tornadovm.base.version}
+                 TornadoVM: ${tornadovm.base.version}${jdk.version.suffix}${tornadovm.dev.suffix} -
+                 tracks whatever TornadoVM tag tornadovm.base.version is currently pointed at
+                 (top-level properties): "-dev" for day-to-day testing against a locally-built
+                 TornadoVM checkout, stripped automatically in the release profile so a real
+                 release always resolves the plain GA coordinate instead.
                  Adds add-modules jdk.incubator.vector (still incubating in JDK21)
             ─────────────────────────────────────────────────────────────────────── -->
             <profile>
@@ -153,7 +159,7 @@
                     <maven.compiler.source>21</maven.compiler.source>
                     <maven.compiler.target>21</maven.compiler.target>
                     <jdk.version.suffix>-jdk21</jdk.version.suffix>
-                    <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
+                    <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}${tornadovm.dev.suffix}</tornadovm.version>
                 </properties>
                 <build>
                     <plugins>
@@ -175,7 +181,8 @@
             <!-- ─── JDK 25 ───────────────────────────────────────────────────────────
                  Auto-activates for JDK 25.0.2+ builds (minimum required version).
                  Publishes: gpu-llama3:${revision}-jdk25
-                 TornadoVM: ${tornadovm.base.version}-jdk25
+                 TornadoVM: ${tornadovm.base.version}-jdk25${tornadovm.dev.suffix} - see the
+                 jdk21 profile above for why the dev suffix is composed in here too.
                  Vector API is still incubating in JDK 25 (JEP 508 — 10th Incubator);
                  add-modules jdk.incubator.vector is required for compilation.
             ─────────────────────────────────────────────────────────────────────── -->
@@ -186,7 +193,7 @@
                     <maven.compiler.source>25</maven.compiler.source>
                     <maven.compiler.target>25</maven.compiler.target>
                     <jdk.version.suffix>-jdk25</jdk.version.suffix>
-                    <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}</tornadovm.version>
+                    <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}${tornadovm.dev.suffix}</tornadovm.version>
                 </properties>
                 <build>
                     <plugins>
@@ -208,9 +215,10 @@
             <!-- ─── JDK 26 ───────────────────────────────────────────────────────────
                  Auto-activates for JDK 26.x builds.
                  Publishes: gpu-llama3:${revision}-jdk26
-                 TornadoVM: pinned to the locally-built 5.2.1-jdk26-dev artifacts (no
-                 5.0.0-jdk26 release exists yet, so tornadovm.base.version is overridden
-                 to 5.2.1 here and composed with tornadovm.dev.suffix below).
+                 TornadoVM: ${tornadovm.base.version}-jdk26${tornadovm.dev.suffix} - inherits
+                 tornadovm.base.version from the top-level properties (no override needed here;
+                 no GA TornadoVM release for jdk26 exists below that version yet, only the
+                 locally-built "-dev" artifacts tornadovm.dev.suffix composes in by default).
                  Vector API is still incubating in JDK 26; add-modules jdk.incubator.vector
                  is required for compilation.
             ─────────────────────────────────────────────────────────────────────── -->
@@ -221,7 +229,6 @@
                     <maven.compiler.source>26</maven.compiler.source>
                     <maven.compiler.target>26</maven.compiler.target>
                     <jdk.version.suffix>-jdk26</jdk.version.suffix>
-                    <tornadovm.base.version>5.2.1</tornadovm.base.version>
                     <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}${tornadovm.dev.suffix}</tornadovm.version>
                 </properties>
                 <build>
@@ -245,9 +252,8 @@
                  Auto-activates for JDK 27+ builds (JVMCI fully removed upstream,
                  openjdk/jdk#30834 — see the matching jdk27 profile in TornadoVM's own pom).
                  Publishes: gpu-llama3:${revision}-jdk27
-                 TornadoVM: pinned to the locally-built 5.2.1-jdk27-dev artifacts (no
-                 5.0.0-jdk27 release exists yet, so tornadovm.base.version is overridden
-                 to 5.2.1 here and composed with tornadovm.dev.suffix below).
+                 TornadoVM: ${tornadovm.base.version}-jdk27${tornadovm.dev.suffix} - inherits
+                 tornadovm.base.version from the top-level properties, same as jdk26 above.
                  No enable-preview: unlike the jdk21/jdk25 profiles, this project's sources
                  compile clean at release 27 with only add-modules jdk.incubator.vector,
                  so the base build's enable-preview arg is dropped via combine.self="override".
@@ -259,7 +265,6 @@
                     <maven.compiler.source>27</maven.compiler.source>
                     <maven.compiler.target>27</maven.compiler.target>
                     <jdk.version.suffix>-jdk27</jdk.version.suffix>
-                    <tornadovm.base.version>5.2.1</tornadovm.base.version>
                     <tornadovm.version>${tornadovm.base.version}${jdk.version.suffix}${tornadovm.dev.suffix}</tornadovm.version>
                 </properties>
                 <build>
@@ -283,11 +288,14 @@
                 <properties>
                     <maven.javadoc.skip>false</maven.javadoc.skip>
                     <gpg.skip>false</gpg.skip>
-                    <!-- Overrides the "-dev" default (see top-level properties) so a real
-                         release never publishes a POM depending on an unpublished
-                         tornado-api/tornado-runtime:*-dev coordinate. Only takes effect once
-                         jdk26/jdk27 are added to deploy-maven-central.yml's matrix, and only
-                         once a GA TornadoVM release exists for those JDKs to point at instead. -->
+                    <!-- Overrides the "-dev" default (see top-level properties) for all four
+                         JDK profiles, so a real release never publishes a POM depending on an
+                         unpublished tornado-api/tornado-runtime:*-dev coordinate - it always
+                         resolves plain ${tornadovm.base.version}${jdk.version.suffix} instead,
+                         i.e. whatever GA TornadoVM tag tornadovm.base.version currently names.
+                         Deploying jdk26/jdk27 additionally requires adding matrix entries to
+                         deploy-maven-central.yml, and a GA TornadoVM release actually published
+                         for those JDKs - see that workflow. -->
                     <tornadovm.dev.suffix></tornadovm.dev.suffix>
                 </properties>
                 <build>


### PR DESCRIPTION
### Summary

  Extends GPULlama3.java's JDK support from `{21, 25}` to `21` plus an open-ended `22+` range (22, 23, 24, 25, 26, 27, and future releases), tracking TornadoVM's own move to a single consolidated `jdk22plus` SDK build. Replaces the short-lived per-version `jdk25`/`jdk26`/`jdk27` Maven profiles with one
  `jdk22plus` profile, fixes `llama-tornado` to handle JDK 27's removal of JVMCI, and updates all docs/release automation to match.

  ### Why

  - TornadoVM dropped separate `jdk25`/`jdk26`/`jdk27` dev builds in favor of one `jdk22plus` SDK that runs unchanged across the whole range — this repo's `pom.xml` had drifted into three near-duplicate profiles chasing that per-version, which was both unnecessary and left a JDK 26.x activation gap.
  - JDK 27 removed the platform `jdk.internal.vm.ci` module entirely (openjdk/jdk#30834); `-XX:+EnableJVMCI` became a fatal unrecognized VM option and TornadoVM ships a vendored `jdk.internal.vm.ci` module to compensate. `llama-tornado` needed to detect this and branch its JVM flags accordingly instead of
  always assuming JVMCI is present.

  ### Changes

  **`pom.xml`**
  - Collapsed `jdk25`/`jdk26`/`jdk27` into one `jdk22plus` profile, activation `[22,)` — closes the JDK 26.x activation gap that existed between the old `jdk25` (`[25.0.2,)`) and a since-added `jdk26` profile.
  - Bumped tracked TornadoVM base version to `5.2.1`, parameterized via `tornadovm.dev.suffix` (defaults to `-dev` for local/CI builds against a dev TornadoVM checkout, stripped to empty in the `release` profile so real releases resolve the plain GA coordinate).
  - `jdk22plus` drops `--enable-preview` (FFM is final since JDK 22) and compiles with `--add-modules jdk.incubator.vector` only (Vector API still incubating through at least JDK 27 / JEP 508).

  **`llama-tornado`**
  - Detects the running JDK's major version from `$JAVA_HOME/bin/java -version`.
  - JDK 27+: skips `-XX:+EnableJVMCI`/`--enable-preview`, sets `-Djdk.internal.vm.ci.enabled=true` and the `--add-exports` needed by TornadoVM's vendored `jdk.internal.vm.ci` module, and puts that module on the module path.
  - JDK 22–26: patches in TornadoVM's frozen JDK-21-shaped `jvmci-21.0.2.jar` via `--patch-module`, since the platform `jdk.vm.ci.*` interfaces on those releases have drifted from what the reflection providers were compiled against.
  - Mirrors the branching TornadoVM's own `tornado.py`/`tornado --printJavaFlags` already does, since this script builds its Java invocation independently.

  **`.github/workflows/deploy-maven-central.yml`**
  - Matrix entry `jdk25`/`25.0.2-open` → `jdk22plus`/`25.0.2-open` (one build within the range now covers publishing the whole `jdk22plus` artifact; noted that GA `5.2.1-jdk22plus` isn't on Maven Central yet, only the `-dev` line, so this entry will fail resolution until TornadoVM cuts that GA release — same
  caveat the prior jdk26/jdk27 note carried).

  **`.github/workflows/prepare-release.yml`**
  - README dependency-snippet generator updated from `jdk21`/`jdk25` to `jdk21`/`jdk22plus` (was still hardcoding the now-removed `jdk25` profile, which would have written broken artifact coordinates on the next release).

  **`README.md`**
  - Prerequisites, Java badge, and Maven/Gradle snippets updated from `21, 25` to `21, 22+ (22–27+)` / `jdk22plus`.

  **`.claude/skills/build-n-run-engine/SKILL.md`, `.claude/skills/build-tornado/SKILL.md`**
  - Prerequisite JDK lists updated from `21, 25, or 27` to `21, or 22+ (22–27+)`; build step notes updated to describe the consolidated `jdk22plus` profile instead of per-version `jdk25`/`jdk27`.

  ### Testing

  - [x] Build on JDK 21 (`jdk21` profile)
  - [x] Build on JDK 22–26 (`jdk22plus` profile, `--patch-module` JVMCI path)
  - [x] Build on JDK 27 (`jdk22plus` profile, no-JVMCI path)